### PR TITLE
Seppop strata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - WARNINGS_ARE_ERRORS=1
     - _R_CHECK_FORCE_SUGGESTS_="FALSE"
     - $BOOTSTRAP_LATEX="TRUE"
+    - NOT_CRAN="true"
 
 notifications:
   email:

--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -295,7 +295,11 @@ rbind.genlight <- function(...){
 setMethod("seppop", signature(x="genlight"), function(x, pop=NULL, treatOther=TRUE, quiet=TRUE, ...){
     ## HANDLE POP ARGUMENT ##
     if(!is.null(pop)) {
+      if (is.language(pop)){
+        setPop(x) <- pop
+      } else {
         pop(x) <- pop
+      }
     }
 
     if(is.null(pop(x))) stop("pop not provided and pop(x) is NULL")

--- a/R/handling.R
+++ b/R/handling.R
@@ -273,6 +273,9 @@ setMethod("seppop", signature(x="genind"), function(x,pop=NULL,truenames=TRUE,re
     if(is.null(pop)) { # pop taken from @pop
         if(is.null(x@pop)) stop("pop not provided and x@pop is empty")
         pop <- pop(x)
+    } else if (is.language(pop)){
+      setPop(x) <- pop
+      pop <- pop(x)
     } else {
         pop <- factor(pop)
     }

--- a/man/seppop.Rd
+++ b/man/seppop.Rd
@@ -24,8 +24,10 @@
 }
 \arguments{
   \item{x}{a \linkS4class{genind} object}
-  \item{pop}{a factor giving the population of each genotype in 'x'. If
-    not provided, seeked in x\$pop.}
+  \item{pop}{a factor giving the population of each genotype in 'x' OR a
+    formula specifying which strata are to be used when converting to a genpop
+    object. If none provided, population factors are sought in x@pop, but if
+    given, the argument prevails on x@pop.}
   \item{truenames}{a logical indicating whether true names should be
     used (TRUE, default) instead of generic labels (FALSE); used if
     res.type is "matrix".}
@@ -53,12 +55,18 @@
 \examples{
 \dontrun{
 data(microbov)
+strata(microbov) <- data.frame(other(microbov))
 
 obj <- seppop(microbov)
 names(obj)
 
 obj$Salers
 
+### example using strata
+obj2 <- seppop(microbov, ~coun/spe)
+names(obj2)
+
+obj2$AF_BI
 
 #### example for genlight objects ####
 x <- new("genlight", list(a=rep(1,1e3),b=rep(0,1e3),c=rep(1, 1e3)))

--- a/tests/testthat/test-seppop.R
+++ b/tests/testthat/test-seppop.R
@@ -1,0 +1,63 @@
+context("Test seppop")
+
+data(microbov)
+
+test_that("seppop will use the internal population factor by default", {
+  skip_on_cran()
+  blist <- seppop(microbov)
+  expect_is(blist, "list")
+  expect_equal(length(blist), nPop(microbov))
+  expect_equivalent(names(blist), popNames(microbov))
+})
+
+test_that("seppop will use the external population factor", {
+  skip_on_cran()
+  coun <- other(microbov)$coun
+  clist <- seppop(microbov, pop = coun)
+  expect_is(clist, "list")
+  expect_equal(length(clist), nlevels(coun))
+  expect_equivalent(names(clist), levels(coun))
+})
+
+test_that("seppop will use formula input", {
+  skip_on_cran()
+  strata(microbov) <- data.frame(other(microbov))
+  slist <- seppop(microbov, pop = ~spe)
+  setPop(microbov) <- ~spe
+  expect_is(slist, "list")
+  expect_equal(length(slist), nPop(microbov))
+  expect_equivalent(names(slist), popNames(microbov))
+})
+
+
+
+x <- new("genlight", list(a=rep(1,1e3),b=rep(0,1e3),c=rep(1, 1e3)), parallel = FALSE)
+pop(x) <- c("pop1","pop2", "pop1")
+
+test_that("seppop will work for genlight objects", {
+  skip_on_cran()
+  plist <- seppop(x)
+  expect_is(plist, "list")
+  expect_equal(length(plist), nPop(x))
+  expect_equivalent(names(plist), popNames(x))
+})
+
+test_that("seppop will work for genlight objects with external factor", {
+  skip_on_cran()
+  uniqpop <- rev(LETTERS)[1:3]
+  ulist <- seppop(x, pop = uniqpop)
+  expect_is(ulist, "list")
+  expect_equal(length(ulist), length(uniqpop))
+  expect_equivalent(names(ulist), sort(uniqpop))
+})
+
+test_that("seppop will work for genlight objects with formula", {
+  skip_on_cran()
+  uniqpop <- rev(LETTERS)[1:3]
+  strata(x) <- data.frame(pop = pop(x), uni = uniqpop, all = rep("A", 3))
+  setPop(x) <- ~all
+  alist <- seppop(x, pop = ~all)
+  expect_is(alist, "list")
+  expect_equal(length(alist), nPop(x))
+  expect_equivalent(names(alist), popNames(x))
+})

--- a/tests/testthat/test_subset.R
+++ b/tests/testthat/test_subset.R
@@ -4,13 +4,17 @@ data("nancycats", package = "adegenet")
 
 test_that("subsetters work for genind objects", {
   skip_on_cran()
-  test_that(nInd(nancycats[1:10]), equals(10))
-  test_that(nLoc(nancycats[loc = locNames(nancycats)[1]]), equals(1))
+  expect_equivalent(nInd(nancycats[1:10]), 10)
+  expect_equivalent(nLoc(nancycats[loc = locNames(nancycats)[1]]), 1)
+  expect_equivalent(nLoc(nancycats[loc = 1]), 1)
+  expect_equivalent(nLoc(nancycats[loc = -1]), 8)
 })
 
 test_that("subsetters work for genind objects", {
   skip_on_cran()
   nanpop <- genind2genpop(nancycats, quiet = TRUE)
-  test_that(nPop(nanpop[1:10]), equals(1))
-  test_that(nLoc(nanpop[loc = locNames(nanpop)[1]]), equals(1))
+  expect_equivalent(nPop(nanpop[1:10]), 10)
+  expect_equivalent(nLoc(nanpop[loc = locNames(nanpop)[1]]), 1)
+  expect_equivalent(nLoc(nanpop[loc = 1]), 1)
+  expect_equivalent(nLoc(nanpop[loc = -1]), 8)
 })


### PR DESCRIPTION
This adds two things

1. The ability to specify strata when using `seppop` (akin to what I added in `genind2genpop`)
2. Setting the `NOT_CRAN` environment variable in travis so that tests will run on travis. They will always skip on cran, but this makes sure that everything behind the scenes are working so you don't have to run tests locally. 