### PR TITLE
Small speedup to snpbin

### DIFF
--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -1,8 +1,11 @@
 
 # Function to subset raw vectors
 .subsetbin <- function(x, i){
-    xint <- as.integer(rawToBits(x)[i])
+    # Take a raw vector, subset the bits and then convert to integers.
+    xint   <- as.integer(rawToBits(x)[i])
+    # Figure out how many zeroes are needed to pad the end.
     zeroes <- 8 - (length(xint) %% 8)
+    # Convert the integer vector with zeroes on the end back into a raw vector.
     return(packBits(c(xint, rep(0L, zeroes))))
 }
 

--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -1,7 +1,7 @@
 
 # Function to subset raw vectors
 .subsetbin <- function(x, i){
-    xint <- as.integer(rawToBits(x))[i]
+    xint <- as.integer(rawToBits(x)[i])
     zeroes <- 8 - (length(xint) %% 8)
     return(packBits(c(xint, rep(0L, zeroes))))
 }


### PR DESCRIPTION
I realized that the subsetter was converting all the raw bits to integers before subsetting. If the subsetting happens before the integer conversion, we see a speedup in the data with large numbers of SNPs.

Protocol the same as #48.

Old Method:

```
Unit: milliseconds
           expr        min         lq       mean     median         uq       max neval cld
  x[, the_loci]   5.185082   5.678802   7.731961   6.007779   7.175650 149.25734   200 a
  y[, the_loci]   5.902340   6.467108   7.996073   7.000335   8.356582  39.65144   200 a
  z[, the_loci]  22.080076  26.274703  30.389466  28.280454  31.426308 189.91701   200  b
 zz[, the_loci] 142.129836 165.874361 235.373325 191.655808 309.998984 480.83209   200   c
```

New Method:

```
Unit: milliseconds
           expr       min         lq       mean     median         uq       max neval cld
  x[, the_loci]  5.181068   5.522196   6.350872   6.133190   6.624304  12.54894   200 a
  y[, the_loci]  5.676456   6.080247   7.126351   6.584142   7.596402  35.41565   200 a
  z[, the_loci] 10.286474  13.144538  16.275613  15.327015  17.514597 165.40598   200  b
 zz[, the_loci] 93.555897 103.086456 131.967272 108.340221 121.095159 323.77547   200   c
```