### PR TITLE
chooseCN fix - Inverse distance, infinite values

### DIFF
--- a/R/chooseCN.R
+++ b/R/chooseCN.R
@@ -240,7 +240,7 @@ chooseCN <- function(xy,ask=TRUE, type=NULL, result.type="nb", d1=NULL, d2=NULL,
         }
         if(a<1) { a <- 1 }
         thres <- mean(cn)/1e8
-        if(dmin > thres) dmin <- thres
+        if(dmin < thres) dmin <- thres
         cn[cn < dmin] <- dmin
         cn <- 1/(cn^a)
         diag(cn) <- 0


### PR DESCRIPTION
Dear Dr. Jombart,
I tried to build a connection network for sPCA and found that maybe there is a typo in `chooseCN` code for the type 7 graph (inverse distance).

To avoid infinite spatial proximities you substitute the minimum distance between points with a small threshold:
`    thres <- mean(cn)/1e8`                 # cn at this step is a distance matrix
`    if(dmin > thres) dmin <- thres`
If somebody will choose very small dmin (e.g., `dmin = 0`) this condition will be FALSE.
Hence, at the next step  `cn <- 1/(cn^a)`  we will obtain *Inf* values and at the end `mat2listw` will return an error.

I suppose that condition in `if(dmin > thres) dmin <- thres`
should be changed to `if(dmin < thres) dmin <- thres`
https://github.com/thibautjombart/adegenet/blob/96f8cb2659a81c61e4afad725bf57cf0180a2a54/R/chooseCN.R#L243

With best regards,
Vladimir