### PR TITLE
fix a typo affecting glPca(center & scale)

### DIFF
--- a/R/glFunctions.R
+++ b/R/glFunctions.R
@@ -350,7 +350,7 @@ glPca <- function(x, center=TRUE, scale=FALSE, nf=NULL, loadings=TRUE, alleleAsU
                     a <- as.integer(a) / ploid.a
                     a[is.na(a)] <- vecMeans[is.na(a)]
                     b <- as.integer(b) / ploid.b
-                    a[is.na(a)] <- vecMeans[is.na(a)]
+                    b[is.na(b)] <- vecMeans[is.na(b)]
                     return( sum( ((a-vecMeans)*(b-vecMeans))/vecVar, na.rm=TRUE ) )
                 }
             }


### PR DESCRIPTION
Seems to be caused by copy-paste programming.

Replacing NA values in the same vector `a` twice does not seem meaningful.