### PR TITLE
changed ward to ward.D in find.clusters.data.frame

### DIFF
--- a/R/find.clust.R
+++ b/R/find.clust.R
@@ -145,7 +145,7 @@ find.clusters.data.frame <- function(x, clust=NULL, n.pca=NULL, n.clust=NULL, st
                 n.clust <- min( which(myStat < temp))-1
             }
             if(criterion=="diffNgroup") {
-                temp <- cutree(hclust(dist(diff(myStat)), method="ward"), k=2)
+                temp <- cutree(hclust(dist(diff(myStat)), method="ward.D"), k=2)
                 goodgrp <- which.min(tapply(diff(myStat), temp, mean))
                 n.clust <- max(which(temp==goodgrp))+1
             }


### PR DESCRIPTION
The function `adegenet::find.clusters` appears to be throwing a warning.

    library(poppr)
    data("Pinf", package = "poppr")
    Pinf.l <- seppop(Pinf)
    find.clusters(Pinf.l[[1]], max.n = 20, n.pca = 10, scale = FALSE, choose.n.clust=F, quiet=T)
    The "ward" method has been renamed to "ward.D"; note new "ward.D2"

This appears to be due to `stats::hclust` changing its method name from 'ward' to 'ward.D'. This PR updates the call in `adegenet::find.clusters` so the warning is not thrown.