### PR TITLE
attempt to fix #184

### DIFF
--- a/R/find.clust.R
+++ b/R/find.clust.R
@@ -390,7 +390,8 @@ find.clusters.genlight <- function(x, clust = NULL, n.pca = NULL, n.clust = NULL
     ## find sub clusters
     for(i in levels(clust)){
         if(!quiet) cat("\nLooking for sub-clusters in cluster",i,"\n")
-        myArgs$x <- x[clust==i, ]
+        myArgs$x <- x[clust==i, , drop = FALSE]
+        myArgs$max.n.clust <- nrow(x[clust==i, , drop = FALSE]) - 1
         temp <- do.call(find.clusters, myArgs)$grp
         levels(temp) <- paste(i, levels(temp), sep=".")
         newFac[clust==i] <- as.character(temp)


### PR DESCRIPTION
The issue was that max.n.clust was set at round(n/10) for the entire data set, but the
clustering step would bork when it was told to find
more clusters than there were samples.

This fix sets the maximum number of clusters for
each popualtion to be n - 1