### PR TITLE
Allow seppop to handle missing population assignment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@ BUG FIXES
     alleles in the current data set, regardless of whether or not these were
     dropped from the data matrix. 
     See https://github.com/thibautjombart/adegenet/issues/234 for details.
+    
+  - `seppop()` will now take into account `NA` population assignments with the
+    new `keepNA` argument. 
+    See https://github.com/thibautjombart/adegenet/pull/236 for details.
 
 			CHANGES IN ADEGENET VERSION 2.1.1
 BUG FIXES

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: adegenet
-Version: 2.1.1
+Version: 2.1.2
 Encoding: UTF-8
 Title: Exploratory Analysis of Genetic and Genomic Data
 Author: Thibaut Jombart, Zhian N. Kamvar, Caitlin Collins, Roman Lustrik, Marie-

--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -348,23 +348,15 @@ rbind.genlight <- function(...){
 ##########
 ## seppop
 ##########
-setMethod("seppop", signature(x="genlight"), function(x, pop=NULL, treatOther=TRUE, quiet=TRUE, ...){
-    ## HANDLE POP ARGUMENT ##
-    if(!is.null(pop)) {
-      if (is.language(pop)){
-        setPop(x) <- pop
-      } else {
-        pop(x) <- pop
-      }
-    }
-
-    if(is.null(pop(x))) stop("pop not provided and pop(x) is NULL")
-
-    ## PERFORM SUBSETTING ##
-    kObj <- lapply(levels(pop(x)), function(lev) x[pop(x)==lev, , treatOther=treatOther, quiet=quiet, ...])
-    names(kObj) <- levels(pop(x))
-
-    return(kObj)
+setMethod("seppop", signature(x="genlight"), function(x, pop=NULL, treatOther=TRUE, keepNA = FALSE, quiet=TRUE, ...){
+  .seppop_internal(
+    x = x,
+    pop = pop,
+    treatOther = treatOther,
+    keepNA = keepNA,
+    quiet = quiet,
+    ...
+  )
 }) # end seppop
 
 

--- a/R/handling.R
+++ b/R/handling.R
@@ -280,8 +280,6 @@ setMethod(
     truenames <- TRUE # this argument will be deprecated
     
     ## misc checks
-    if (!is.genind(x))
-      stop("x is not a valid genind object")
     if (is.null(pop)) {
       # pop taken from @pop
       if (is.null(x@pop))

--- a/R/handling.R
+++ b/R/handling.R
@@ -265,40 +265,49 @@ setMethod("$<-","genind",function(x,name,value) {
 setGeneric("seppop", function(x, ...) standardGeneric("seppop"))
 
 ## genind
-setMethod("seppop", signature(x="genind"), function(x,pop=NULL,truenames=TRUE,res.type=c("genind","matrix"),
-                              drop=FALSE, treatOther=TRUE, quiet=TRUE){
+setMethod(
+  f = "seppop", 
+  signature(x = "genind"), 
+  definition = function(x,
+                        pop = NULL,
+                        truenames = TRUE,
+                        res.type = c("genind", "matrix"),
+                        drop = FALSE,
+                        treatOther = TRUE,
+                        keepNA = FALSE,
+                        quiet = TRUE) {
     ## checkType(x)
     truenames <- TRUE # this argument will be deprecated
-
+    
     ## misc checks
-    if(!is.genind(x)) stop("x is not a valid genind object")
-    if(is.null(pop)) { # pop taken from @pop
-        if(is.null(x@pop)) stop("pop not provided and x@pop is empty")
-        pop <- pop(x)
-    } else if (is.language(pop)){
+    if (!is.genind(x))
+      stop("x is not a valid genind object")
+    if (is.null(pop)) {
+      # pop taken from @pop
+      if (is.null(x@pop))
+        stop("pop not provided and x@pop is empty")
+      pop <- pop(x)
+    } else if (is.language(pop)) {
       setPop(x) <- pop
       pop <- pop(x)
     } else {
-        pop <- factor(pop)
+      pop <- factor(pop)
     }
-
-
     res.type <- match.arg(res.type)
-
-    ## pop <- x@pop # comment to take pop arg into account
-
     ## make a list of genind objects
-    kObj <- lapply(levels(pop), function(lev) x[pop==lev, , drop=drop, treatOther=treatOther, quiet=quiet])
+    kObj <- lapply(levels(pop), function(lev) x[pop == lev, , drop = drop, treatOther = treatOther, quiet = quiet])
     names(kObj) <- levels(pop)
-
+    
     ## res is a list of genind
-    if(res.type=="genind"){ return(kObj) }
-
+    if (res.type == "genind") {
+      return(kObj)
+    }
+    
     ## res is list of matrices
     res <- lapply(kObj, function(obj) tab(obj))
-
+    
     return(res)
-}) # end seppop
+  }) # end seppop
 
 
 

--- a/man/seppop.Rd
+++ b/man/seppop.Rd
@@ -41,6 +41,9 @@
     \code{@other} slot should be treated as well (TRUE), or not
     (FALSE). See details in accessor documentations
     (\code{\link{pop}}).}
+  \item{keepNA}{If there are individuals with missing population information,
+    should they be pooled into a separate population (TRUE), or excluded (FALSE,
+    default).}
   \item{quiet}{a logical indicating whether warnings should be issued
     when trying to subset components of the \code{@other} slot (TRUE),
     or not (FALSE, default). }

--- a/tests/testthat/test-seppop.R
+++ b/tests/testthat/test-seppop.R
@@ -1,4 +1,4 @@
-context("Test seppop")
+context("Test seppop for genind")
 
 data(microbov)
 
@@ -29,7 +29,25 @@ test_that("seppop will use formula input", {
   expect_equivalent(names(slist), popNames(microbov))
 })
 
+test_that("seppop will throw a warning if there are missing populations", {
+  skip_on_cran()
+  # Create 10 ambiguous population assignments
+  pop(microbov)[sample(nInd(microbov), 10)] <- NA
+  
+  # Missing data will throw a warning by default
+  expect_warning(res <- seppop(microbov), "missing population information")
+  # The resulting list will be equal to the number of populations
+  expect_length(res, nPop(microbov))
+  
+  # keepNA does not throw a warning
+  expect_failure(expect_warning(res2 <- seppop(microbov, keepNA = TRUE)))
+  # The resulting list will have 1 more population
+  expect_length(res2, nPop(microbov) + 1L)
+  # This population will be equal to the number of missing samples
+  expect_equal(nInd(res2[[length(res2)]]), 10L)
+})
 
+context("Test seppop for genight")
 
 x <- new("genlight", list(a=rep(1,1e3),b=rep(0,1e3),c=rep(1, 1e3)), parallel = FALSE)
 pop(x) <- c("pop1","pop2", "pop1")


### PR DESCRIPTION
This was brought up in https://github.com/grunwaldlab/poppr/issues/189. Basically, if any populations assignments are set to `NA`, then `seppop()` will erroneously insert those individuals in all of the subsequent populations, resulting in errors down the road. 

This PR fixes that by adding a `keepNA` argument and warning the user if there are missing population assignments. 