### PR TITLE
Make loc.n.all backwards compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
   apt:
     packages:
       - libudunits2-dev
+      - libgdal-dev
 
 # enable when codecov link established
 # r_github_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ cran: http://cran.at.r-project.org
 cache: packages
 warnings_are_errors: false
 
+addons:
+  apt:
+    packages:
+      - libudunits2-dev
+
 # enable when codecov link established
 # r_github_packages:
 #   - jimhester/covr
@@ -17,8 +22,8 @@ before_install:
   - Rscript -e 'update.packages(ask = FALSE)'
 
 # enable when codecov link established
-# after_success:
-#   - Rscript -e 'library(covr);codecov()'
+after_success:
+  - Rscript -e 'library(covr);codecov()'
 
 notifications:
   email:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -114,4 +114,4 @@ Collate:
     zzz.R
 License: GPL (>=2)
 LazyLoad: yes
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -302,7 +302,7 @@ setMethod("alleles","gen", function(x, ...){
 setReplaceMethod("alleles","gen", function(x, value){
     if(!is.list(value)) stop("replacement value must be a list")
     if(length(value)!=nLoc(x)) stop("replacement list must be of length nLoc(x)")
-    if(any(lengths(value) != lengths(x$all.names))) stop("number of replacement alleles do not match that of the object")
+    if(any(lengths(value) != x@loc.n.all)) stop("number of replacement alleles do not match that of the object")
     x@all.names <- value
     names(x@all.names) <- locNames(x)
     return(x)

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -65,24 +65,27 @@ setMethod("locFac","genpop", function(x,...){
 #######
 # nAll
 #######
-setGeneric("nAll", function(x,...){
+setGeneric("nAll", function(x, onlyObserved = FALSE, ...){
     standardGeneric("nAll")
 })
 
 
-setMethod("nAll","gen", function(x,...){
+setMethod("nAll","gen", function(x, onlyObserved = FALSE, ...){
   if (x@type == "PA"){
     return(ncol(x@tab))
+  } else if (onlyObserved) {
+    present_alleles <- colSums(tab(x), na.rm = TRUE) > 0L
+    return(vapply(split(present_alleles, x@loc.fac), sum, integer(1)))
   } else {
     return(x@loc.n.all)
   }
 })
 
-setMethod("nAll","genind", function(x,...){
+setMethod("nAll","genind", function(x, onlyObserved = FALSE, ...){
   callNextMethod()
 })
 
-setMethod("nAll","genpop", function(x,...){
+setMethod("nAll","genpop", function(x, onlyObserved = FALSE, ...){
     callNextMethod()
 })
 

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -195,7 +195,7 @@ setReplaceMethod("locNames","gen",function(x,value) {
     names(x@all.names) <- value
     levels(x@loc.fac) <- value
     names(x@loc.n.all) <- value
-    newColNames <- paste(rep(value, x@loc.n.all), unlist(x@all.names), sep=".")
+    newColNames <- paste(rep(value, lengths(x@all.names)), unlist(x@all.names), sep=".")
     colnames(x@tab) <- newColNames
 
     ## return
@@ -299,7 +299,7 @@ setMethod("alleles","gen", function(x, ...){
 setReplaceMethod("alleles","gen", function(x, value){
     if(!is.list(value)) stop("replacement value must be a list")
     if(length(value)!=nLoc(x)) stop("replacement list must be of length nLoc(x)")
-    if(any(sapply(value, length) != x$loc.n.all)) stop("number of replacement alleles do not match that of the object")
+    if(any(lengths(value) != lengths(x$all.names))) stop("number of replacement alleles do not match that of the object")
     x@all.names <- value
     names(x@all.names) <- locNames(x)
     return(x)

--- a/R/basicMethods.R
+++ b/R/basicMethods.R
@@ -17,7 +17,7 @@ setMethod("$<-","genpop",function(x,name,value) {
   present_alleles <- colSums(tab(x), na.rm = TRUE) > 0L
 
   x@all.names <- split(all.vec, loc.fac)
-  x@loc.n.all <- vapply(split(present_alleles, loc.fac), sum, integer(1))
+  x@loc.n.all <- setNames(tabulate(loc.fac), levels(loc.fac)) #vapply(split(present_alleles, loc.fac), sum, integer(1))
   x@loc.fac   <- loc.fac
   return(x)
 }
@@ -269,8 +269,8 @@ setMethod ("show", "genind", function(object){
 
   cat("\n   @tab: ", nrow(tab(x)), "x", ncol(tab(x)), "matrix of allele counts" )
 
-  if(!is.null(nAll(x))){
-    alleletxt <- paste("(range: ", paste(range(nAll(x)), collapse="-"), ")", sep="")
+  if (!is.null(nAll(x))){
+    alleletxt <- paste("(range: ", paste(range(nAll(x, onlyObserved = FALSE)), collapse="-"), ")", sep="")
     cat("\n   @loc.n.all: number of alleles per locus", alleletxt)
   }
 
@@ -355,7 +355,7 @@ setMethod ("show", "genpop", function(object){
   cat("\n   @tab: ", nrow(tab(x)), "x", ncol(tab(x)), "matrix of allele counts" )
 
   if(!is.null(nAll(x))){
-    alleletxt <- paste("(range: ", paste(range(nAll(x)), collapse="-"), ")", sep="")
+    alleletxt <- paste("(range: ", paste(range(nAll(x, onlyObserved = FALSE)), collapse="-"), ")", sep="")
     cat("\n   @loc.n.all: number of alleles per locus", alleletxt)
   }
 
@@ -427,7 +427,7 @@ setMethod ("summary", signature(object="genind"), function(object, verbose = TRU
 
 
   ## codom case ##
-  res$loc.n.all <- nAll(x)
+  res$loc.n.all <- nAll(x, onlyObserved = TRUE)
 
   temp <- tab(genind2genpop(x,quiet=TRUE))
 
@@ -496,7 +496,7 @@ setMethod ("summary", signature(object="genpop"), function(object, verbose = TRU
 
 
   ## codom case ##
-  res$loc.n.all <- nAll(x)
+  res$loc.n.all <- nAll(x, onlyObserved = TRUE)
 
   res$pop.n.all <- apply(tab(x),1,function(r) sum(r>0,na.rm=TRUE))
 

--- a/man/accessors.Rd
+++ b/man/accessors.Rd
@@ -139,7 +139,7 @@
     \item{alleles<-}{sets the alleles of each locus using a list with
       one character vector for each locus.}
     \item{other}{returns the content of the \code{@other} slot
-      (misc. information); returns \code{NULL} if the slot is empty or of
+      (misc. information); returns \code{NULL} if the slot is onlyObserved or of
       length zero.}
     \item{other<-}{sets the content of the \code{@other} slot
       (misc. information); the provided value needs to be a list; it
@@ -149,6 +149,7 @@
 \usage{
 nInd(x, \dots)
 nLoc(x, \dots)
+nAll(x, onlyObserved = FALSE, \dots)
 nPop(x, \dots)
 pop(x)
 indNames(x, \dots)
@@ -168,6 +169,11 @@ ploidy(x, \dots)
 }
 \arguments{
   \item{x}{a \linkS4class{genind} or a \linkS4class{genpop} object.}
+  \item{onlyObserved}{a logical indicating whether the allele count should
+    also include the alleles with onlyObserved columns in the matrix. Defaults
+    to \code{FALSE}, which will report only the observed alleles in the
+    given population. \code{onlyObserved = TRUE} will be the equivalent of
+    \code{table(locFac(x))}, but faster.}
   \item{withAlleles}{a logical indicating whether the result should be
     of the form [locus name].[allele name], instead of [locus name].}
   \item{\dots}{further arguments to be passed to other methods
@@ -194,10 +200,9 @@ ploidy(x, \dots)
   that are present in the subset. To achieve better control of
   polymorphism of the data, see \code{\link{isPoly}}.
   
-  \code{nAll()} will always reflect the number of columns per locus that 
-  contain at least one observation. This means that the sum of the this vector 
-  will not necessarily equal the number of columns in the data unless you use 
-  \code{drop = TRUE} when subsetting. 
+  \code{nAll()} reflects the number of columns per locus present in the current
+  gen object. If \code{onlyObserved = TRUE}, then the number of columns with at
+  least one non-missing allele is shown. 
 }
 \examples{
 data(nancycats)
@@ -219,7 +224,9 @@ obj <- nancycats[pop=c(4, 8)]
 obj
 popNames(obj)
 pop(obj)
-nAll(obj) # count number of alleles among these two populations
+nAll(obj, onlyObserved = TRUE) # count number of alleles among these two populations
+nAll(obj) # count number of columns in the data
+all(nAll(obj, onlyObserved = TRUE) == lengths(alleles(obj))) # will be FALSE since drop = FALSE
 all(nAll(obj) == lengths(alleles(obj))) # will be FALSE since drop = FALSE
 
 # let's isolate two markers, fca23 and fca90

--- a/tests/testthat/test_accessors.R
+++ b/tests/testthat/test_accessors.R
@@ -59,6 +59,10 @@ test_that("'[' method works for genind objects", {
   mic2Loc   <- microbov[loc = two_random_loci]
   mic2Loc10 <- microbov[ten_random_samples, loc = two_random_loci]
 
+  # Ensure that the replacement methods work. The tests below will confirm
+  alleles(mic2Loc)  <- alleles(mic2Loc)
+  locNames(mic2Loc) <- locNames(mic2Loc)
+
   names(two_random_loci) <- two_random_loci
   two_random_loci <- two_random_loci[levels(loci)]
 


### PR DESCRIPTION
A bug/feature that was fixed/added from #234 / #235 was changing the `@loc.n.all` slot so that it would report the number of alleles present in the population instead of the number of columns/locus. It turned out that this was a bad idea because it broke the `alleles()<-` accessor (not to mention poppr). 

To fix this, I've implemented an option `onlyObserved` in the `nAll()` accessor, which will return the observed number of alleles when `TRUE`, but defaults to `FALSE`, which returns the number of columns per locus. This has been set to `TRUE` in the `summary()` function to make sure the promise of #234 is kept. 