### PR TITLE
Speed up df2genind

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,9 @@ MISC
   - `snapclust()` will give a better warning message when the number of
     samples in the dataset exceeds computer precision. See
     https://github.com/thibautjombart/adegenet/issues/221 for details.
+    
+  - `df2genind()` now imports data >100x faster 
+    (@KlausVigo, https://github.com/thibautjombart/adegenet/pulls/260)
 
 			CHANGES IN ADEGENET VERSION 2.1.1
 BUG FIXES

--- a/R/import.R
+++ b/R/import.R
@@ -272,7 +272,7 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
     ## unfold data for each cell of the table
     if (any(ploidy > 1)){
         allele.data <- strsplit(X, sep)
-        n.items <- sapply(allele.data, length)
+        n.items <- lengths(allele.data)
         locus.data <- rep(rep(loc.names, each = nind), n.items)
         ind.data <- rep(rep(ind.names,ncol(X)), n.items)
         allele.data <- unlist(allele.data)
@@ -313,8 +313,10 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
     pos <- tmpfun(locus.data[ind]) 
     
     allele.data <- factor(allele.data, levels=unique(allele.data))
+    ind.data    <- factor(ind.data, levels=ind.names)
+    
     out         <- table(ind.data, allele.data)
-    out         <- out[ind.names, , drop = FALSE] # table sorts alphabetically. This resets.
+#    out         <- out[ind.names, , drop = FALSE] # table sorts alphabetically. This resets.
 
     ## force type 'matrix'
     class(out) <- NULL

--- a/R/import.R
+++ b/R/import.R
@@ -231,7 +231,7 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
         if(is.null(ncode)) stop("please indicate either the separator (sep) or the number of characters coding an allele (ncode).")
 
         ## add "/" as separator
-        X <- gsub(paste("([[:alnum:]]{",ncode,"})",sep=""), "\\1/", X)
+        X <- gsub(paste0("([[:alnum:]]{",ncode,"})"), "\\1/", X)
         X <- sub("/$","",X)
         sep <- "/"
     }
@@ -298,6 +298,20 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
 
     ## get matrix of allele counts
     allele.data <- paste(locus.data, allele.data, sep=".")
+
+    tmpfun <- function(x){
+      tab <- tabulate(factor(x, levels = unique(x)))
+      to <- cumsum(tab)
+      from <- c(0L, to[-length(to)])+ 1L
+      res <- mapply(seq, from, to, SIMPLIFY=FALSE)
+      names(res) <- unique(x)
+      res
+    }    
+    tmp <- unique(allele.data)
+    ind <- match(tmp, allele.data)
+    ## named list with position of the columns for each locus 
+    pos <- tmpfun(locus.data[ind]) 
+    
     allele.data <- factor(allele.data, levels=unique(allele.data))
     out         <- table(ind.data, allele.data)
     out         <- out[ind.names, , drop = FALSE] # table sorts alphabetically. This resets.
@@ -321,14 +335,10 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
     #  }
     ## This one is modified from above to make everything more explicit.
     if (length(NA.posi) > 0) {
-      out.colnames <- colnames(out)
       NA.row <- match(NA.ind, rownames(out))
-      loc <- paste0(NA.locus, "\\.")
-      uloc <- unique(loc)
-      loc.list <- lapply(uloc, FUN = function(x, y) {
-        grep(pattern = paste("^", x, sep = ""), x = out.colnames, perl = TRUE)
-      }, y = out.colnames)
-      NA.col <- match(loc, uloc)
+      uloc <- unique(NA.locus)
+      loc.list <- pos[uloc] ## subset pos 
+      NA.col <- match(NA.locus, uloc)
 
       # Coordinates for missing rows
       missing.ind <- vapply(loc.list, length, integer(1))[NA.col]
@@ -354,9 +364,8 @@ df2genind <- function(X, sep=NULL, ncode=NULL, ind.names=NULL, loc.names=NULL,
       # M_KH1837           1
     }
     if(check.ploidy){
-      ploidmat <- vapply(loc.names, function(i){
-        rowSums(out[, grepl(paste0("^", i, "\\."), colnames(out)), drop = FALSE], na.rm = TRUE)
-        }, FUN.VALUE = double(nrow(out)))
+      ploidmat <- vapply(pos, function(i) rowSums(out[, i, drop = FALSE], 
+                         na.rm = TRUE), FUN.VALUE = double(nrow(out)))      
       if (max(ploidmat, na.rm = TRUE) > max(ploidy, na.rm = TRUE)) {
         oran <- paste(range(ploidmat, na.rm = TRUE), collapse = "-")
         eran <- paste(range(ploidy, na.rm = TRUE), collapse = "-")
@@ -1590,7 +1599,7 @@ fasta2genlight <- function(file, quiet=FALSE, chunkSize=1000, saveNbAlleles=FALS
     letterOK <- c("a","g","c","t","A","G","C","T")
     POOL <- lapply(POOL, function(e) e[e %in% letterOK]) # keep only proper letters
     ## POOL <- lapply(POOL, setdiff, "-")
-    nb.alleles <- sapply(POOL, length)
+    nb.alleles <- lengths(POOL)
     snp.posi <- nb.alleles==2
     if(all(!snp.posi)){
         warning("No polymorphism in the alignment - returning empty object")


### PR DESCRIPTION
Hi Thibaut,

how are things? We are analyzing some RADseq data in our lab and could not transform a vcf files to genind objects. `df2genind` run out of memory and R stalled. 
So I made some improvements to `df2genind`. This code seems to work as intended, but maybe you have to check with some more tricky data sets to test it more thorough. 

E.g. the following code take now .2 seconds instead of 6 seconds on my machine.
```
library(adegenet)
library(vcfR)

data(vcfR_example)
my_genind <- vcfR2genind(vcf)
```
It should also be possible to transform larger data sets, which should be useful for quite a few people. 

I also cleaned up some code, e.g. replace `paste()` with `paste0()` or using `lengths(x)` instead of `sapply(x, length)`. 


Cheers, 
Klaus



