### PR TITLE
Add pop argument to genlight bracket accessor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
 			CHANGES IN ADEGENET VERSION 2.1.2
+BUG FIX
+
+  - `seppop()` correctly subsets genlight objects now. (@rdinnager, #270) 
+
+			CHANGES IN ADEGENET VERSION 2.1.2
 
 NEW MANAGEMENT
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: adegenet
-Version: 2.1.2
+Version: 2.1.3
 Encoding: UTF-8
 Title: Exploratory Analysis of Genetic and Genomic Data
 Author: Thibaut Jombart, Zhian N. Kamvar, Caitlin Collins, Roman Lustrik, Marie-

--- a/R/basicMethods.R
+++ b/R/basicMethods.R
@@ -48,18 +48,19 @@ setMethod("[", signature(x="genind", i="ANY", j="ANY", drop="ANY"), function(x, 
   }
 
   ## HANDLE 'POP'
-  if(!is.null(pop) && !is.null(pop(x))){
-    if(is.factor(pop)) pop <- as.character(pop)
-    if(!is.character(pop)) pop <- popNames(x)[pop]
-    temp <- !pop %in% pop(x)
-    if (any(temp)) { # if wrong population specified
-      warning(paste("the following specified populations do not exist:", paste0(pop[temp], collapse = ", ")), call. = FALSE)
-      if (all(temp)){
-        warning("no populations selected - ignoring", call. = FALSE)
-        pop <- pop(x)
-      }
-    }
-    i <- pop(x) %in% pop
+  if (!is.null(pop) && !is.null(pop(x))){
+    i <- .get_pop_inds(x, pop)
+    # if(is.factor(pop)) pop <- as.character(pop)
+    # if(!is.character(pop)) pop <- popNames(x)[pop]
+    # temp <- !pop %in% pop(x)
+    # if (any(temp)) { # if wrong population specified
+    #   warning(paste("the following specified populations do not exist:", paste0(pop[temp], collapse = ", ")), call. = FALSE)
+    #   if (all(temp)){
+    #     warning("no populations selected - ignoring", call. = FALSE)
+    #     pop <- pop(x)
+    #   }
+    # }
+    # i <- pop(x) %in% pop
   }
 
   ## handle population factor

--- a/R/basicMethods.R
+++ b/R/basicMethods.R
@@ -50,17 +50,6 @@ setMethod("[", signature(x="genind", i="ANY", j="ANY", drop="ANY"), function(x, 
   ## HANDLE 'POP'
   if (!is.null(pop) && !is.null(pop(x))){
     i <- .get_pop_inds(x, pop)
-    # if(is.factor(pop)) pop <- as.character(pop)
-    # if(!is.character(pop)) pop <- popNames(x)[pop]
-    # temp <- !pop %in% pop(x)
-    # if (any(temp)) { # if wrong population specified
-    #   warning(paste("the following specified populations do not exist:", paste0(pop[temp], collapse = ", ")), call. = FALSE)
-    #   if (all(temp)){
-    #     warning("no populations selected - ignoring", call. = FALSE)
-    #     pop <- pop(x)
-    #   }
-    # }
-    # i <- pop(x) %in% pop
   }
 
   ## handle population factor

--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -108,7 +108,7 @@ setMethod("[", signature(x="SNPbin", i="ANY"), function(x, i) {
 
 ## genlight
 setMethod("[", signature(x = "genlight", i = "ANY", j = "ANY", drop = "ANY"),
-          function(x, i, j, ..., treatOther = TRUE, quiet = TRUE, drop = FALSE) {
+          function(x, i, j, ..., pop=NULL, treatOther=TRUE, quiet=TRUE, drop=FALSE) {
     if (missing(i)) i <- TRUE
     if (missing(j)) j <- TRUE
 
@@ -118,6 +118,10 @@ setMethod("[", signature(x = "genlight", i = "ANY", j = "ANY", drop = "ANY"),
     ## recycle logicals if needed
     if(!is.null(i) && is.logical(i)) i <- rep(i, length=ori.n)
     if(!is.null(j) && is.logical(j)) j <- rep(j, length=ori.p)
+
+    if (!is.null(pop) && !is.null(pop(x))){
+      i <- .get_pop_inds(x, pop)
+    }
 
 
     ## SUBSET INDIVIDUALS ##

--- a/R/handling.R
+++ b/R/handling.R
@@ -310,6 +310,22 @@ setGeneric("seppop", function(x, ...) standardGeneric("seppop"))
   kObj
 }
 
+.get_pop_inds <- function(x, pop) {
+
+  if(is.factor(pop)) pop <- as.character(pop)
+  if(!is.character(pop)) pop <- popNames(x)[pop]
+  temp <- !pop %in% pop(x)
+  if (any(temp)) { # if wrong population specified
+    warning(paste("the following specified populations do not exist:", paste0(pop[temp], collapse = ", ")), call. = FALSE)
+    if (all(temp)){
+      warning("no populations selected - ignoring", call. = FALSE)
+      pop <- pop(x)
+    }
+  }
+  
+  pop(x) %in% pop
+}
+
 ## genind
 setMethod(
   f = "seppop", 

--- a/tests/testthat/test-seppop.R
+++ b/tests/testthat/test-seppop.R
@@ -58,6 +58,7 @@ test_that("seppop will work for genlight objects", {
   expect_is(plist, "list")
   expect_equal(length(plist), nPop(x))
   expect_equivalent(names(plist), popNames(x))
+  expect_equivalent(vapply(plist, nInd, integer(1)), setNames(c(2, 1), popNames(x)))
 })
 
 test_that("seppop will work for genlight objects with external factor", {
@@ -67,6 +68,7 @@ test_that("seppop will work for genlight objects with external factor", {
   expect_is(ulist, "list")
   expect_equal(length(ulist), length(uniqpop))
   expect_equivalent(names(ulist), sort(uniqpop))
+  expect_equal(vapply(ulist, nInd, integer(1)), rep(1, 3))
 })
 
 test_that("seppop will work for genlight objects with formula", {
@@ -78,4 +80,5 @@ test_that("seppop will work for genlight objects with formula", {
   expect_is(alist, "list")
   expect_equal(length(alist), nPop(x))
   expect_equivalent(names(alist), popNames(x))
+  expect_equal(nInd(alist[[1]]), nInd(x))
 })

--- a/tests/testthat/test-seppop.R
+++ b/tests/testthat/test-seppop.R
@@ -54,7 +54,7 @@ pop(x) <- c("pop1","pop2", "pop1")
 
 test_that("seppop will work for genlight objects", {
   skip_on_cran()
-  plist <- seppop(x)
+  plist <- seppop(x) 
   expect_is(plist, "list")
   expect_equal(length(plist), nPop(x))
   expect_equivalent(names(plist), popNames(x))
@@ -68,7 +68,7 @@ test_that("seppop will work for genlight objects with external factor", {
   expect_is(ulist, "list")
   expect_equal(length(ulist), length(uniqpop))
   expect_equivalent(names(ulist), sort(uniqpop))
-  expect_equal(vapply(ulist, nInd, integer(1)), rep(1, 3))
+  expect_equal(vapply(ulist, nInd, integer(1)), c(X = 1, Y = 1, Z = 1))
 })
 
 test_that("seppop will work for genlight objects with formula", {


### PR DESCRIPTION
This will fix #270. @rdinnager, can you check this with your analysis and confirm that it does what you expect? This is what I get:

``` r
  library(adegenet)
#> Loading required package: ade4
#> Registered S3 method overwritten by 'spdep':
#>   method   from
#>   plot.mst ape
#> 
#>    /// adegenet 2.1.2 is loaded ////////////
#> 
#>    > overview: '?adegenet'
#>    > tutorials/doc/questions: 'adegenetWeb()' 
#>    > bug reports/feature requests: adegenetIssues()
x <- matrix(sample(0:2, 40*10, replace = TRUE), ncol = 40, nrow = 10) 
x <- new("genlight", x)
x
#>  /// GENLIGHT OBJECT /////////
#> 
#>  // 10 genotypes,  40 binary SNPs, size: 16.9 Kb
#>  0 (0 %) missing data
#> 
#>  // Basic content
#>    @gen: list of 10 SNPbin
#> 
#>  // Optional content
#>    @other: a list containing: elements without names
pop(x) <- c(rep("A", 5), rep("B", 5))
adegenet::seppop(x)
#> $A
#>  /// GENLIGHT OBJECT /////////
#> 
#>  // 5 genotypes,  40 binary SNPs, size: 10.1 Kb
#>  0 (0 %) missing data
#> 
#>  // Basic content
#>    @gen: list of 5 SNPbin
#> 
#>  // Optional content
#>    @pop: population of each individual (group size range: 5-5)
#>    @other: a list containing: elements without names 
#> 
#> 
#> $B
#>  /// GENLIGHT OBJECT /////////
#> 
#>  // 5 genotypes,  40 binary SNPs, size: 10.1 Kb
#>  0 (0 %) missing data
#> 
#>  // Basic content
#>    @gen: list of 5 SNPbin
#> 
#>  // Optional content
#>    @pop: population of each individual (group size range: 5-5)
#>    @other: a list containing: elements without names
```

<sup>Created on 2020-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>