### PR TITLE
Set all parallel = FALSE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+			CHANGES IN ADEGENET VERSION 2.1.5
+
+PARALLEL COMPUTATION
+
+ - parallel computation defaults to `FALSE` from now on to avoid frustrating
+   errors on windows machines.
+
 			CHANGES IN ADEGENET VERSION 2.1.4
 
 DOCUMENTATION

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adegenet
 Title: Exploratory Analysis of Genetic and Genomic Data
-Version: 2.1.4
+Version: 2.1.5
 Authors@R: 
     c(person(given = "Thibaut",
              family = "Jombart",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -102,7 +102,7 @@ Suggests:
     poppr
 Encoding: UTF-8
 LazyLoad: yes
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate:
     'adegenet.package.R'
     'datasets.R'

--- a/R/import.R
+++ b/R/import.R
@@ -1415,7 +1415,7 @@ extract.PLINKmap <- function(file, x = NULL){
 #' @export
 #' @rdname read.PLINK
 read.PLINK <- function(file, map.file=NULL, quiet=FALSE, chunkSize=1000,
-                       parallel=require("parallel"), n.cores=NULL, ...){
+                       parallel=FALSE, n.cores=NULL, ...){
     ## HANDLE ARGUMENTS ##
     ext <- .readExt(file)
     ext <- toupper(ext)
@@ -1529,7 +1529,7 @@ read.PLINK <- function(file, map.file=NULL, quiet=FALSE, chunkSize=1000,
 ## Function fasta2genlight
 ###########################
 fasta2genlight <- function(file, quiet=FALSE, chunkSize=1000, saveNbAlleles=FALSE,
-                       parallel=require("parallel"), n.cores=NULL, ...){
+                       parallel=FALSE, n.cores=NULL, ...){
     ## HANDLE ARGUMENTS ##
     ext <- .readExt(file)
     ext <- toupper(ext)

--- a/man/fasta2genlight.Rd
+++ b/man/fasta2genlight.Rd
@@ -18,8 +18,8 @@
   on parallel architectures (needs the package \code{parallel}).
 }
 \usage{
-fasta2genlight(file, quiet=FALSE, chunkSize = 1000, saveNbAlleles=FALSE,
-               parallel = require("parallel"), n.cores = NULL, \dots)
+fasta2genlight(file, quiet = FALSE, chunkSize = 1000, saveNbAlleles = FALSE,
+               parallel = FALSE, n.cores = NULL, \dots)
 }
 \arguments{
   \item{file}{ a character string giving the path to the file to

--- a/man/read.PLINK.Rd
+++ b/man/read.PLINK.Rd
@@ -13,7 +13,7 @@ read.PLINK(
   map.file = NULL,
   quiet = FALSE,
   chunkSize = 1000,
-  parallel = require("parallel"),
+  parallel = FALSE,
   n.cores = NULL,
   ...
 )


### PR DESCRIPTION
It turns out that `read.PLINK()` and `fasta2genlight()` were still harboring the demon `parallel=require('parallel')`. Since parallel computation did not _really_ speed things up, I've set them to default as `FALSE` for everyone. 

This will address #313 until we have a better solution.  