### PR TITLE
summmary.spca bug fix for matrices and data frames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,11 @@ Authors@R:
       person(given = "Alexandre",
              family = "Courtiol",
              role = "ctb",
-             comment = c(ORCID = "0000-0003-0637-2959")))
+             comment = c(ORCID = "0000-0003-0637-2959")),
+      person(given = "Lindsay V.",
+             family = "Clark",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-3881-9252")))
 Description: Toolset for the exploration of genetic and genomic
     data. Adegenet provides formal (S4) classes for storing and handling
     various genetic data, including genetic markers with varying ploidy

--- a/R/spca.R
+++ b/R/spca.R
@@ -408,6 +408,7 @@ summary.spca <- function (object, ..., printres=TRUE) {
   ## compute original pca
   # prepare data
   obj <- eval(appel$obj)
+  if(is.null(obj)) obj <- eval(appel$x) # for matrices and data frames
   if(is.null(appel$truenames)) appel$truenames <- FALSE
 
   f1 <- function(vec){
@@ -418,6 +419,8 @@ summary.spca <- function (object, ..., printres=TRUE) {
 
   if(is.genind(obj)) { X <- obj@tab }
   if(is.genpop(obj)) { X <- makefreq(obj, quiet=TRUE) }
+  if(is.matrix(obj)) { X <- obj }
+  if(is.data.frame(obj)) { X <- as.matrix(obj) }
 
   X <- apply(X,2,f1)
 


### PR DESCRIPTION
Fixes a bug where `summary.spca` only worked on `spca` objects derived from `genind` and `genpop` objects.  Now `summary.spca` and `screeplot.spca` both work when matrices and data frames are used for `spca`.

Resolves #328 