### PR TITLE
Fix bug where genlight subsetting with no loci specified results in an extra bit

### DIFF
--- a/.github/workflows/recheck.yml
+++ b/.github/workflows/recheck.yml
@@ -1,0 +1,18 @@
+on:
+  workflow_dispatch:
+    inputs:
+      which:
+        type: choice
+        description: Which dependents to check
+        options:
+          - strong
+          - most
+
+name: Reverse dependency check
+
+jobs:
+  revdep_check:
+    name: Reverse check ${{ inputs.which }} dependents
+    uses: r-devel/recheck/.github/workflows/recheck.yml@v1
+    with:
+      which: ${{ inputs.which }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
 BUG FIX
 
 - genlight objects subset without any arguments to loci no longer gain an
-  extra byte. (reported: @maxcoulter, #363)
+  extra byte. (reported: @maxecoulter, #363)
 
 			CHANGES IN ADEGENET VERSION 2.1.10
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+			CHANGES IN ADEGENET VERSION 2.1.11
+
+BUG FIX
+
+- genlight objects subset without any arguments to loci no longer gain an
+  extra byte. (reported: @maxcoulter, #363)
+
 			CHANGES IN ADEGENET VERSION 2.1.10
 
 CRAN MAINTENANCE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adegenet
 Title: Exploratory Analysis of Genetic and Genomic Data
-Version: 2.1.10
+Version: 2.1.11
 Authors@R: 
     c(person(given = "Thibaut",
              family = "Jombart",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,10 @@ Authors@R:
        person(given = "Pavel",
               family = "Dimens",
               role = "ctb",
-              comment = c(ORCID = "0000-0003-3823-0373"))
+              comment = c(ORCID = "0000-0003-3823-0373")),
+       person(given = "Max",
+              family = "Coulter",
+              role = "ctb")
        )
 Description: Toolset for the exploration of genetic and genomic
     data. Adegenet provides formal (S4) classes for storing and handling

--- a/R/glHandle.R
+++ b/R/glHandle.R
@@ -4,7 +4,10 @@
     # Take a raw vector, subset the bits and then convert to integers.
     xint   <- as.integer(rawToBits(x)[i])
     # Figure out how many zeroes are needed to pad the end.
-    zeroes <- 8 - (length(xint) %% 8)
+    extra_bits <- length(xint) %% 8
+    # https://github.com/thibautjombart/adegenet/issues/363
+    # Fix to a bug caught by @maxcoulter. In the case 
+    zeroes <- if (extra_bits > 0) 8 - extra_bits else 0
     # Convert the integer vector with zeroes on the end back into a raw vector.
     return(packBits(c(xint, rep(0L, zeroes))))
 }

--- a/tests/testthat/test_genlight.R
+++ b/tests/testthat/test_genlight.R
@@ -28,6 +28,24 @@ test_that("Genlight objects can be created predictably", {
 })
 
 
+test_that("(#363) genlight objects don't gain extra byte after subsetting", {
+  # https://github.com/thibautjombart/adegenet/issues/363
+  
+  dat <- list(toto=c(1,2,0,0), titi=c(NA,1,2,0), tata=c(NA,0,2, NA))#3 individuals, 4 binary snps
+  
+  x <- new("genlight", gen = dat, ploidy = c(2,2,2,2), 
+    loc.names = c("m1", "m2", "m3", "m4"), 
+    loc.all = c("A/T", "A/T", "A/T", "A/T") 
+  )
+  x2 <- x[]
+  # the output tables should be equal
+  expect_equal(tab(x), tab(x2))
+  # the snps should be equal
+  expect_equal(x, x2)
+
+})
+
+
 x <- new("genlight", list(a=1,b=0,c=1), other=list(1:3, letters, data.frame(2:4)), parallel = FALSE)
 pop(x) <- c("pop1","pop1", "pop2")
 


### PR DESCRIPTION
This will fix #363 