### PR TITLE
Update of the original package for the imported 'multispati' function

### DIFF
--- a/R/spca.R
+++ b/R/spca.R
@@ -5,7 +5,7 @@
 ## require ade4 and spdep
 ##
 ## generic functions were derived from
-## those of multispati class (ade4)
+## those of multispati class (adespatial)
 ##
 ## T. Jombart (t.jombart@imperial.ac.uk)
 ## 31 may 2007

--- a/man/spca.Rd
+++ b/man/spca.Rd
@@ -23,7 +23,7 @@
     \item \code{genpop}: any \linkS4class{genpop} object is accepted
   }
   
-  The core computation use \code{multispati} from the \code{ade4} package.\cr
+  The core computation use \code{multispati} from the \code{adespatial} package.\cr
   
   Besides the set of \code{spca} functions, other functions include:
   \itemize{
@@ -255,8 +255,7 @@ of Moran's I and Geary's c. \emph{Geographical Analysis}, \bold{16}, 17--24.
 }
 \seealso{\code{\link{spcaIllus}} and \code{\link{rupica}} for datasets illustrating the sPCA \cr
   \code{\link{global.rtest}} and \code{\link{local.rtest}} \cr
-  \code{\link{chooseCN}}, \code{\link[ade4]{multispati}},
-  \code{\link[ade4]{multispati.randtest}}\cr
+  \code{\link{chooseCN}}, \code{\link[adespatial]{multispati}}\cr
   \code{convUL}, from the package 'PBSmapping' to convert longitude/latitude to
   UTM coordinates.
 }

--- a/spca_randtest(modified)
+++ b/spca_randtest(modified)
@@ -9,7 +9,7 @@ spca_randtest <-function(x, nperm = 499, p=.05){
   get_stats <- function(obj){
     obj_pca <- ade4::dudi.pca(obj, center = FALSE, scale = FALSE,
                               scannf = FALSE)
-    obj_spca <- ade4::multispati(dudi = obj_pca,
+    obj_spca <- adespatial::multispati(dudi = obj_pca,
                                  listw = x$lw, scannf = FALSE,
                                  nfposi = 1, nfnega = 1)
     lambda <- obj_spca$eig


### PR DESCRIPTION
`multispati` is now deprecated in `ade4` and must be imported from `adespatial`.