### PR TITLE
Fix missing-allele matching in STRUCTURE imports

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -753,9 +753,9 @@ read.genepop <- function(file, ncode=2L, quiet=FALSE){
 #' created object.
 #' @param row.marknames an integer giving the index of the row containing the
 #' names of the markers. '0' if absent.
-#' @param NA.char the character string coding missing data. "-9" by default.
-#' Note that in any case, series of zero (like "000") are interpreted as NA
-#' too.
+#' @param NA.char the character string coding a missing allele. "-9" by default.
+#' Matching is literal against complete allele tokens, so "0" does not match
+#' "120". If either allele is missing, the whole diploid genotype is missing.
 #' @param pop an optional factor giving the population of each individual.
 #' @param sep a character string used as separator between alleles.
 #' @param ask a logical specifying if the function should ask for optional
@@ -870,7 +870,9 @@ read.structure <- function(file, n.ind=NULL, n.loc=NULL,  onerowperind=NULL,
     mat <- txt[(lastline-n+1):lastline]
     mat <- t(as.data.frame(strsplit(mat,"[[:blank:]]+")))
     rownames(mat) <- 1:n
-    gen <- mat[, (ncol(mat)-p+1):ncol(mat)]
+    gen <- mat[, (ncol(mat)-p+1):ncol(mat), drop=FALSE]
+    ## Match whole allele tokens before padding or joining genotypes.
+    missing.alleles <- matrix(gen %in% NA.char, nrow=nrow(gen), ncol=ncol(gen))
 
 
     ## markers names
@@ -920,17 +922,22 @@ read.structure <- function(file, n.ind=NULL, n.loc=NULL,  onerowperind=NULL,
         }
 
         ## reorder matrix of genotypes
-        X <- t(sapply(temp, function(i) paste(gen[i,],gen[i+1,],sep="") ))
+        X <- matrix(unlist(lapply(temp, function(i)
+            paste(gen[i,],gen[i+1,],sep=""))), nrow=n.ind, byrow=TRUE)
+        missing.genotypes <- missing.alleles[temp, , drop=FALSE] |
+            missing.alleles[temp+1, , drop=FALSE]
 
     } else { # if onerowperind
         temp <- seq(1,p-1,by=2)
         X <- paste(gen[,temp] , gen[,temp+1], sep="/")
         X <- matrix(X, nrow=n.ind)
         sep <- "/"
+        missing.genotypes <- missing.alleles[,temp,drop=FALSE] |
+            missing.alleles[,temp+1,drop=FALSE]
     }
 
     ## replace missing values by NAs
-    X <- gsub(NA.char,NA,X)
+    X[missing.genotypes] <- NA
     rownames(X) <- ind.names
     colnames(X) <- loc.names
 

--- a/man/read.structure.Rd
+++ b/man/read.structure.Rd
@@ -23,40 +23,28 @@ read.structure(
 \arguments{
 \item{file}{a character string giving the path to the file to convert, with
 the appropriate extension.}
-
 \item{n.ind}{an integer giving the number of genotypes (or 'individuals') in
 the dataset}
-
 \item{n.loc}{an integer giving the number of markers in the dataset}
-
 \item{onerowperind}{a STRUCTURE coding option: are genotypes coded on a
 single row (TRUE), or on two rows (FALSE, default)}
-
 \item{col.lab}{an integer giving the index of the column containing labels
 of genotypes. '0' if absent.}
-
 \item{col.pop}{an integer giving the index of the column containing
 population to which genotypes belong. '0' if absent.}
-
 \item{col.others}{an vector of integers giving the indexes of the columns
 containing other informations to be read. Will be available in @other of the
 created object.}
-
 \item{row.marknames}{an integer giving the index of the row containing the
 names of the markers. '0' if absent.}
-
-\item{NA.char}{the character string coding missing data. "-9" by default.
-Note that in any case, series of zero (like "000") are interpreted as NA
-too.}
-
+\item{NA.char}{the character string coding a missing allele. "-9" by default.
+Matching is literal against complete allele tokens, so "0" does not match
+"120". If either allele is missing, the whole diploid genotype is missing.}
 \item{pop}{an optional factor giving the population of each individual.}
-
 \item{sep}{a character string used as separator between alleles.}
-
 \item{ask}{a logical specifying if the function should ask for optional
 informations about the dataset (TRUE, default), or try to be as quiet as
 possible (FALSE).}
-
 \item{quiet}{logical stating whether a conversion message must be printed
 (TRUE,default) or not (FALSE).}
 }
@@ -77,12 +65,9 @@ with the STRUCTURE format can easily be read into R using \code{read.table}
 or \code{read.csv} and then converted using \code{\link{df2genind}}.
 }
 \examples{
-
 obj <- read.structure(system.file("files/nancycats.str",package="adegenet"),
   onerowperind=FALSE, n.ind=237, n.loc=9, col.lab=1, col.pop=2, ask=FALSE)
-
 obj
-
 }
 \references{
 Pritchard, J.; Stephens, M. & Donnelly, P. (2000) Inference of

--- a/tests/testthat/test-structure-missing-alleles.R
+++ b/tests/testthat/test-structure-missing-alleles.R
@@ -1,0 +1,43 @@
+test_that("STRUCTURE missing codes match complete allele tokens in both layouts", {
+    for (missing in c("0", "-9", ".")) {
+        for (one.row in c(TRUE, FALSE)) {
+            # L1 has complete, partially missing, and fully missing genotypes.
+            # L2 keeps all individuals in the output for checking missing calls.
+            a <- matrix(c("118", "120", "126", "132", missing, "128",
+                          missing, missing), ncol=2, byrow=TRUE)
+            lines <- character()
+            for (i in 1:4) {
+                if (one.row) {
+                    lines <- c(lines, paste(c(paste0("ind",i), 1, a[i,], "140", "142"), collapse=" "))
+                } else {
+                    lines <- c(lines, paste(c(paste0("ind",i), 1, a[i,1], "140"), collapse=" "),
+                               paste(c(paste0("ind",i), 1, a[i,2], "142"), collapse=" "))
+                }
+            }
+            f <- tempfile(fileext=".stru")
+            writeLines(lines, f)
+            g <- read.structure(f, n.ind=4, n.loc=2, onerowperind=one.row,
+                                col.lab=1, col.pop=2, row.marknames=0,
+                                NA.char=missing, ask=FALSE, quiet=TRUE)
+            unlink(f)
+            expect_identical(indNames(g), paste0("ind",1:4))
+            expect_true(all(c("118","120","126","132") %in% alleles(g)[[1]]))
+            counts <- seploc(g, res.type="matrix")[[1]]
+            expect_equal(unname(rowSums(counts)[1:2]), c(2,2))
+            expect_true(all(is.na(counts[3:4,,drop=FALSE])))
+            expect_equal(unname(rowSums(seploc(g,res.type="matrix")[[2]])), rep(2,4))
+        }
+    }
+})
+
+test_that("two-row STRUCTURE input preserves single-locus dimensions", {
+    f <- tempfile(fileext=".stru")
+    on.exit(unlink(f))
+    writeLines(c("ind1 1 118", "ind1 1 120", "ind2 1 126", "ind2 1 128"), f)
+    g <- read.structure(f, n.ind=2, n.loc=1, onerowperind=FALSE,
+                        col.lab=1, col.pop=2, row.marknames=0,
+                        NA.char="0", ask=FALSE, quiet=TRUE)
+    expect_identical(indNames(g), c("ind1","ind2"))
+    expect_equal(nLoc(g), 1L)
+    expect_equal(unname(rowSums(tab(g))), c(2,2))
+})


### PR DESCRIPTION
## Summary

Fixes #348.

Match missing codes against complete allele tokens before padding or joining genotypes, rather than applying a regular expression to the assembled genotype.

## Problem

With `NA.char = "0"`, the current implementation also matches valid alleles such as `120`. This can mark valid genotypes as missing and remove individuals when no scored loci remain.

A missing code containing regular-expression characters, such as `.`, can also match unrelated allele values.

## Changes

- Identify missing alleles using literal whole-token matching.
- Preserve the existing rule that either missing allele makes the whole diploid genotype missing.
- Preserve matrix dimensions for single-locus, two-row STRUCTURE input.
- Update the source documentation and help page.

## Regression tests

Tests cover:

- Missing codes `"0"`, `"-9"`, and `"."`.
- Both one-row and two-row STRUCTURE layouts.
- Valid alleles containing zero.
- Partially and fully missing genotypes.
- Preservation of individual identifiers.
- Single-locus, two-row input.

All 33 assertions pass with the correction, without warnings or failures. The original implementation fails these regression tests.

## Validation scope

These are targeted tests using the patched R source with the installed adegenet backend, not a complete package check.