### PR TITLE
Fix incomplete-genotype export and population overrides in genind2df

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -73,6 +73,14 @@
 #' into columns (defaults to \code{FALSE}). This will only work with data with
 #' consistent ploidies.
 #'
+#' @details With \code{oneColPerAll = TRUE}, observed allele copies are
+#' retained and unobserved copies are padded with real \code{NA} values.
+#' Zero-copy genotypes or genotypes containing missing allele counts produce
+#' missing values in all allele columns. Allele order does not imply phase.
+#' Genotypes with more copies than the declared ploidy are rejected.
+#' This handling of incomplete genotypes follows the problem and approach
+#' described by \code{ntakebay} in GitHub issue 320.
+#'
 #' @return a data.frame of raw allelic data, with individuals in rows and loci in column
 #'
 #' @author Thibaut Jombart \email{t.jombart@@imperial.ac.uk}
@@ -111,7 +119,7 @@ genind2df <- function(x, pop=NULL, sep="", usepop=TRUE, oneColPerAll = FALSE){
   ## PA case ##
   if(x@type=="PA"){
       res <- tab(x)
-      if(usepop && !is.null(pop)) res <- cbind.data.frame(pop=pop(x),res)
+      if(usepop && !is.null(pop)) res <- cbind.data.frame(pop=pop,res)
       return(res) # exit here
   }
 
@@ -137,14 +145,21 @@ genind2df <- function(x, pop=NULL, sep="", usepop=TRUE, oneColPerAll = FALSE){
   ## if use one column per allele
   if(oneColPerAll){
     if (all(x@ploidy == x@ploidy[1])){
-      f1 <- function(vec){ # to repeat NA with seperators
-          vec[is.na(vec)] <- paste(rep("NA", x@ploidy[1]), collapse=sep)
-          return(vec)
-      }
-      temp <- lapply(kGen, f1)
-      temp <- lapply(temp, strsplit,sep)
-
-      res <- lapply(temp, function(e) matrix(unlist(e), ncol=x@ploidy[1], byrow=TRUE))
+      ## Build each row from allele counts: do not join and re-split labels.
+      res <- lapply(seq_along(kX), function(i) {
+          counts <- kX[[i]]
+          out <- matrix(NA_character_, nrow=nrow(counts), ncol=x@ploidy[1])
+          for (j in seq_len(nrow(counts))) {
+              copies <- counts[j, ]
+              if (anyNA(copies)) next
+              if (sum(copies) > x@ploidy[1])
+                  stop("Allele counts exceed ploidy for individual ",
+                       indNames(x)[j], " at locus ", locNames(x)[i])
+              observed <- rep(x@all.names[[i]], copies)
+              out[j, seq_along(observed)] <- observed
+          }
+          out
+      })
       res <- data.frame(res,stringsAsFactors=FALSE)
       names(res) <- paste(rep(locNames(x),each=x@ploidy[1]), 1:x@ploidy[1], sep=".")
 

--- a/man/genind2df.Rd
+++ b/man/genind2df.Rd
@@ -8,14 +8,10 @@ genind2df(x, pop = NULL, sep = "", usepop = TRUE, oneColPerAll = FALSE)
 }
 \arguments{
 \item{x}{a \linkS4class{genind} object}
-
 \item{pop}{an optional factor giving the population of each individual.}
-
 \item{sep}{a character string separating alleles. See details.}
-
 \item{usepop}{a logical stating whether the population (argument \code{pop}
 or \code{x@pop} should be used (TRUE, default) or not (FALSE)).}
-
 \item{oneColPerAll}{a logical stating whether or not alleles should be split
 into columns (defaults to \code{FALSE}). This will only work with data with
 consistent ploidies.}
@@ -27,23 +23,27 @@ a data.frame of raw allelic data, with individuals in rows and loci in column
 The function \code{genind2df} converts a \linkS4class{genind} back to a
 data.frame of raw allelic data.
 }
+\details{
+With \code{oneColPerAll = TRUE}, observed allele copies are
+retained and unobserved copies are padded with real \code{NA} values.
+Zero-copy genotypes or genotypes containing missing allele counts produce
+missing values in all allele columns. Allele order does not imply phase.
+Genotypes with more copies than the declared ploidy are rejected.
+This handling of incomplete genotypes follows the problem and approach
+described by \code{ntakebay} in GitHub issue 320.
+}
 \examples{
-
 ## simple example
 df <- data.frame(locusA=c("11","11","12","32"),
 locusB=c(NA,"34","55","15"),locusC=c("22","22","21","22"))
 row.names(df) <- .genlab("genotype",4)
 df
-
 obj <- df2genind(df, ploidy=2, ncode=1)
 obj
 obj@tab
-
-
 ## converting a genind as data.frame
 genind2df(obj)
 genind2df(obj, sep="/")
-
 }
 \seealso{
 \code{\link{df2genind}}, \code{\link{import2genind}}, \code{\link{read.genetix}},

--- a/tests/testthat/test-genind2df-incomplete.R
+++ b/tests/testthat/test-genind2df-incomplete.R
@@ -1,0 +1,50 @@
+test_that("split-allele export preserves incomplete genotypes and rows", {
+    x <- df2genind(data.frame(L1=c("A/A","A/B","B/B","A/B"),
+                             L2=c("C/D","C/C","D/D","C/D")), sep="/", ploidy=2)
+    cols <- which(locFac(x) == locNames(x)[1])
+    x@tab[2,cols] <- c(0L,1L)
+    x@tab[3,cols] <- 0L
+    x@tab[4,cols] <- NA_integer_
+    y <- genind2df(x, oneColPerAll=TRUE, usepop=FALSE)
+    expect_identical(rownames(y), indNames(x))
+    expect_identical(y[[1]], c("A","B",NA_character_,NA_character_))
+    expect_identical(y[[2]], c("A",NA_character_,NA_character_,NA_character_))
+    expect_identical(y[[3]], c("C","C","D","C"))
+    expect_identical(y[[4]], c("D","C","D","D"))
+    x@tab[1,cols] <- c(3L,0L)
+    expect_error(genind2df(x, oneColPerAll=TRUE), "exceed ploidy")
+})
+
+test_that("rupica exports every individual without recycling allele copies", {
+    data(rupica, package="adegenet", envir=environment())
+    expect_warning(y <- genind2df(rupica, oneColPerAll=TRUE, usepop=FALSE), NA)
+    expect_equal(nrow(y), nInd(rupica))
+    expect_equal(ncol(y), 2*nLoc(rupica))
+    expect_identical(rownames(y), indNames(rupica))
+    for (j in seq_len(nLoc(rupica))) {
+        counts <- seploc(rupica,res.type="matrix")[[j]]
+        for (i in seq_len(nInd(rupica))) {
+            emitted <- unlist(y[i, c(2*j-1,2*j)], use.names=FALSE)
+            expected <- if(anyNA(counts[i,])) character() else
+                rep(alleles(rupica)[[j]], counts[i,])
+            expect_identical(sort(emitted[!is.na(emitted)]), sort(unname(expected)))
+        }
+    }
+})
+
+test_that("presence/absence exports honour population overrides", {
+    x <- df2genind(data.frame(L1=c(1,0,1), L2=c(0,1,1)), type="PA",
+                  ncode=1, pop=c("old","old","old"))
+    replacement <- factor(c("a","b","c"))
+    expect_identical(genind2df(x,pop=replacement)$pop, replacement)
+    expect_identical(genind2df(x)$pop, pop(x))
+    expect_equal(genind2df(x,pop=replacement,usepop=FALSE), tab(x))
+})
+
+test_that("split export preserves literal NA and separator allele labels", {
+    x <- df2genind(data.frame(L1=c("AA:BB","AA:AA")),sep=":",ploidy=2)
+    x@all.names[[1]] <- c("NA","A/B")
+    y <- genind2df(x,oneColPerAll=TRUE,usepop=FALSE)
+    expect_identical(y[[1]], c("NA","NA"))
+    expect_identical(y[[2]], c("A/B","NA"))
+})


### PR DESCRIPTION
## Summary

Fixes #320.

Preserve individual alignment when exporting incomplete genotypes with `oneColPerAll = TRUE`, and honour population overrides for presence/absence data.

## Incomplete genotypes

The current implementation joins and splits allele labels, then reshapes the flattened result. Incomplete genotypes contribute fewer allele copies than expected, causing inconsistent dimensions or recycling.

The replacement constructs each individual's allele columns directly from the original counts:

- Retain observed allele copies.
- Pad unobserved copies with real `NA` values.
- Export zero-copy genotypes and genotypes containing missing counts as entirely missing.
- Reject counts exceeding the declared ploidy.
- Preserve literal allele labels, including `"NA"` and labels containing `/`.

Allele order does not imply phase. No new argument is introduced.

## Population overrides

For presence/absence data, use the supplied `pop` value rather than retrieving the object's original population factor again.

## Acknowledgement

Thanks to @ntakebay for identifying the incomplete-genotype problem and proposing padding missing copies and using real NA values in the discussion of #320.

This implementation follows that approach but constructs the output directly from allele counts rather than splitting assembled genotype strings.

## Regression tests

- Incomplete, zero-copy, and missing genotypes.
- Individual alignment and excessive allele counts.
- Every individual–locus combination in the bundled rupica dataset.
- Population overrides for presence/absence data.
- Literal allele-label preservation.

All 3,030 assertions pass with the correction, without warnings or failures. The original implementation fails these tests.

## Validation scope

Testing used the patched R source with the installed adegenet backend. This is targeted validation, not a complete package check.