### PR TITLE
Fit PCA within training splits in DAPC cross-validation

### DIFF
--- a/R/xvalDapc.R
+++ b/R/xvalDapc.R
@@ -60,8 +60,10 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
     train_pca <- dudi.pca(train_dat, nf = n.pca, scannf = FALSE,
                           center = x$CENTER, scale = x$SCALE)
     # dapc() otherwise silently reduces n.pca to the available rank.
+    # LDA's pooled within-group covariance has rank at most N - K.
+    lda_rank_max <- nrow(train_dat) - nlevels(droplevels(train_grp))
     if (min(train_pca$rank, sum(train_pca$eig > 1e-14),
-            nrow(train_dat) - 1L) < n.pca) return(NA_real_)
+            lda_rank_max) < n.pca) return(NA_real_)
     temp.dapc <- suppressWarnings(dapc(train_dat, train_grp, dudi = train_pca,
                                        n.pca = n.pca, n.da = n.da))
     temp.pred <- predict.dapc(temp.dapc, newdata = new_dat)
@@ -209,7 +211,8 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
   if(missing(n.pca.max)) n.pca.max <- min(dim(x))
   if (!length(n.pca.max) || any(!is.finite(n.pca.max)) || any(n.pca.max < 1))
     stop("n.pca.max must contain positive finite values.")
-  n.pca.max <- floor(min(max(n.pca.max), ncol(x), N.training - 1L))
+  lda.rank.max <- N.training - nlevels(grp)
+  n.pca.max <- floor(min(max(n.pca.max), ncol(x), lda.rank.max))
   if (n.pca.max < 1L) stop("Too few training individuals for PCA.")
     
   ## DETERMINE N.PCA IF NEEDED ##
@@ -236,7 +239,8 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
   if (!any(valid))
     stop("No candidate PC count is supported in every training split; reduce n.pca.")
   if (any(!valid))
-    warning("PC counts exceeding the rank of a training split were excluded ",
+    warning("PC counts exceeding the PCA or within-group LDA rank of a ",
+            "training split were excluded ",
             "from selection: ", paste(names(valid)[!valid], collapse = ", "))
   
   

--- a/R/xvalDapc.R
+++ b/R/xvalDapc.R
@@ -11,7 +11,7 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
 # Return randomly sampled indices from a group.
 # @param e group name
 # @param vector of group assignments per sample
-# @param training.set fraction of samples to be kept for validation
+# @param training.set fraction of samples to be kept for training
 .group_sampler <- function(e, grp, training.set){
   group_e   <- grp == e 
   N_group_e <- sum(group_e)
@@ -21,7 +21,8 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
     return(which(group_e))
   } else {
     samp_group <- which(group_e)
-    samp_size <- round(training.set * N_group_e)
+    samp_size <- max(1L, min(N_group_e - 1L,
+                            round(training.set * N_group_e)))
     return(sample(samp_group, size = samp_size))    
   }
 }
@@ -29,14 +30,13 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
 
 # Function to subsample the data. This is to be used as the ran.gen function
 # in the boot function. DATA is a data frame or matrix containing the samples,
-# GRP is the group identities of the samples, PCA is the result of dudi.pca
-# on the full data set, KEEP is the subset of samples based on the training
+# GRP is the group identities of the samples, KEEP is the training subset.
+# CENTER and SCALE specify the transformation fitted within each training
 # set (mle). Note that this function only has two inputs, dat, and mle.
-.boot_group_sampler <- function(dat = list(DATA = NULL, GRP = NULL, PCA = NULL, 
+.boot_group_sampler <- function(dat = list(DATA = NULL, GRP = NULL,
                                            KEEP = NULL), 
                                 mle = NULL){
   to_keep    <- unlist(lapply(levels(dat$GRP), .group_sampler, dat$GRP, mle))
-  dat$PCA$li <- dat$PCA$li[to_keep, , drop = FALSE]
   dat$KEEP   <- to_keep
   return(dat)
 }
@@ -53,13 +53,16 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
     
     new_grp   <- x$GRP[-x$KEEP]
     train_grp <- x$GRP[x$KEEP]      
-    dapclist <- list(train_dat,
-                     train_grp,
-                     n.pca = n.pca,
-                     n.da = n.da,
-                     dudi = x$PCA)
-    temp.dapc <- suppressWarnings(do.call("dapc", dapclist))
-    temp.dapc <- suppressWarnings(dapc(train_dat, train_grp, dudi = x$PCA, 
+    # Fit all preprocessing to the training individuals only.
+    if (all(vapply(as.data.frame(train_dat), function(z) {
+      length(unique(z)) < 2L
+    }, logical(1)))) return(NA_real_)
+    train_pca <- dudi.pca(train_dat, nf = n.pca, scannf = FALSE,
+                          center = x$CENTER, scale = x$SCALE)
+    # dapc() otherwise silently reduces n.pca to the available rank.
+    if (min(train_pca$rank, sum(train_pca$eig > 1e-14),
+            nrow(train_dat) - 1L) < n.pca) return(NA_real_)
+    temp.dapc <- suppressWarnings(dapc(train_dat, train_grp, dudi = train_pca,
                                        n.pca = n.pca, n.da = n.da))
     temp.pred <- predict.dapc(temp.dapc, newdata = new_dat)
     if (identical(result, "overall")){
@@ -84,7 +87,7 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
 # @param grp factor of group assignments per sample
 # @param training.set fraction of samples used for training
 # @param training.set2 NULL or largest possible fraction that can be obtained
-# @param pcaX principal componenets
+# @param center,scale training-set preprocessing options
 # @param result user's choice of result type
 # @param reps the number of replicates per number of retained PCs
 # @param ... methods to be passed on to boot such as parallel and ncores
@@ -92,10 +95,12 @@ xvalDapc <- function (x, ...) UseMethod("xvalDapc")
 ## .get.prop.pred ##
 ####################
 .get.prop.pred <- function(n.pca, x, n.da, groups, grp, training.set, 
-                           pcaX, result = "overall", reps = 100,
+                           center = TRUE, scale = FALSE,
+                           result = "overall", reps = 100,
                            ...){
   
-  bootlist      <- list(DATA = x, GRP = grp, PCA = pcaX, KEEP = 1:nrow(x))
+  bootlist <- list(DATA = x, GRP = grp, KEEP = seq_len(nrow(x)),
+                   CENTER = center, SCALE = scale)
 
   out <- boot::boot(bootlist, .boot_dapc_pred, sim = "parametric", R = reps,
                       ran.gen = .boot_group_sampler, mle = training.set, 
@@ -116,7 +121,23 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
                      n.pca = NULL, n.rep = 30, xval.plot = TRUE, ...){
   
   ## CHECKS ##
+  x <- as.matrix(x)
+  if (!is.numeric(x) || length(dim(x)) != 2L || any(dim(x) == 0L))
+    stop("x must be a non-empty numeric matrix or data frame.")
+  if (anyNA(x))
+    stop("xvalDapc requires complete data; missing values are not imputed. ",
+         "Imputation before cross-validation can use validation information; ",
+         "use a workflow that fits imputation within each training split.")
+  if (any(!is.finite(x))) stop("x must contain finite values.")
   grp <- factor(grp)
+  if (length(grp) != nrow(x) || anyNA(grp) || nlevels(grp) < 2L)
+    stop("grp must identify at least two groups, with one non-missing label per row.")
+  if (length(training.set) != 1L || !is.finite(training.set) ||
+      training.set <= 0 || training.set >= 1)
+    stop("training.set must be between 0 and 1, exclusively.")
+  if (length(n.rep) != 1L || !is.finite(n.rep) || n.rep < 1 || n.rep != floor(n.rep))
+    stop("n.rep must be a positive integer.")
+  result <- match.arg(result)
   n.pca <- n.pca[n.pca > 0]
   if(!is.null(n.da)){
     n.da <- n.da
@@ -149,6 +170,7 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
   groups <- levels(grp)
   ## identify the sizes of groups
   group.n <- as.vector(table(grp))
+  if (all(group.n == 1L)) stop("No individuals are available for validation.")
   ## identify the smallest group size
   popmin <- min(group.n)
   
@@ -177,16 +199,18 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
   if(training.set2 < training.set) training.set <- training.set2
   
   ## get N.training | training.set 
-  N.training <- round(N*training.set)
+  N.training <- sum(ifelse(group.n == 1L, 1L,
+                          pmax(1L, pmin(group.n - 1L,
+                                       round(group.n * training.set)))))
    
   
   
-  ## GET FULL PCA ##
+  ## Bound the candidate grid without fitting a full-data PCA. ##
   if(missing(n.pca.max)) n.pca.max <- min(dim(x))
-  if(length(n.pca.max > 1)) n.pca.max <- max(n.pca.max)
-
-  pcaX      <- dudi.pca(x, nf=n.pca.max, scannf=FALSE, center=center, scale=scale)
-  n.pca.max <- min(n.pca.max, pcaX$rank, N.training-1) # re-defines n.pca.max (so user's input may not be the value used...)
+  if (!length(n.pca.max) || any(!is.finite(n.pca.max)) || any(n.pca.max < 1))
+    stop("n.pca.max must contain positive finite values.")
+  n.pca.max <- floor(min(max(n.pca.max), ncol(x), N.training - 1L))
+  if (n.pca.max < 1L) stop("Too few training individuals for PCA.")
     
   ## DETERMINE N.PCA IF NEEDED ##
   if(n.pca.max < 10){
@@ -198,41 +222,42 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
     n.pca <- round(pretty(1:n.pca.max, runs))
   }
 
-  n.pca <- n.pca[n.pca>0 & n.pca<(N.training-1) & n.pca<n.pca.max]
+  n.pca <- sort(unique(n.pca[is.finite(n.pca) & n.pca > 0 &
+                            n.pca == floor(n.pca) & n.pca <= n.pca.max]))
+  if (!length(n.pca)) stop("No feasible positive integer n.pca values.")
   
   
   ## GET %SUCCESSFUL OF ACCURATE PREDICTION FOR ALL VALUES ##
   res.all <- unlist(lapply(n.pca, .get.prop.pred, x, n.da, groups, grp,
-                           training.set, pcaX, result, 
+                           training.set, center, scale, result,
                            n.rep, ...))
   xval <- data.frame(n.pca=rep(n.pca, each=n.rep), success=res.all)    
+  valid <- tapply(is.finite(xval$success), xval$n.pca, all)
+  if (!any(valid))
+    stop("No candidate PC count is supported in every training split; reduce n.pca.")
+  if (any(!valid))
+    warning("PC counts exceeding the rank of a training split were excluded ",
+            "from selection: ", paste(names(valid)[!valid], collapse = ", "))
   
   
   n.pcaF <- as.factor(xval$n.pca)
   successV <- as.vector(xval$success)
   pca.success <- tapply(successV, n.pcaF, mean)
+  pca.success[!valid] <- NA_real_
   n.opt <- which.max(tapply(successV, n.pcaF, mean))
   
   
   ###### MSE-BASED OPTIMAL n.pca SELECTION:
-  temp <- seq(from=1, to=length(xval$n.pca), by=n.rep)
-  orary <-c(temp+(n.rep-1))
-  index <-c(1:length(temp))
-  lins <-sapply(index, function(e) seq(from=temp[e], to=orary[e]))
-  lin <-c(1:ncol(lins))
-  col <-successV
-  cait<-sapply(lin, function(e) ((col[lins[,e]])-1)^2)
-  FTW <-sapply(lin, function(e) sum(cait[,e])/n.rep)
-  RMSE <- sqrt(FTW)
-  names(RMSE) <- xval$n.pca[temp]
+  RMSE <- sqrt(tapply((successV - 1)^2, n.pcaF, mean))
+  RMSE[!valid] <- NA_real_
   ## if more than one n.pc give highest success, choose the largest one
-  best.n.pca <- names(which(RMSE == min(RMSE)))
+  best.n.pca <- names(which(RMSE == min(RMSE, na.rm = TRUE)))
   if(length(best.n.pca) > 1) best.n.pca <- best.n.pca[length(best.n.pca)]
   
   # DAPC
   n.pca <- as.integer(best.n.pca)
-  n.da <- nlevels(grp)-1
-  dapc1 <- suppressWarnings(dapc(x, grp, n.pca=n.pca, n.da=n.da))
+  dapc1 <- suppressWarnings(dapc(x, grp, n.pca=n.pca, n.da=n.da,
+                                center=center, scale=scale))
   
   # PLOT CROSS-VALIDATION RESULTS
   snps <- x
@@ -241,10 +266,19 @@ xvalDapc.default <- function(x, grp, n.pca.max = 300, n.da = NULL, training.set 
   q.phen <- quantile(random, c(0.025,0.5,0.975))
   
   if(xval.plot==TRUE){
-    smoothScatter(xval$n.pca, successV, nrpoints=Inf, pch=20, col=transp("black"),
+    plot_ok <- is.finite(successV)
+    if (length(unique(xval$n.pca[plot_ok])) > 1L &&
+        length(unique(successV[plot_ok])) > 1L) {
+      smoothScatter(xval$n.pca[plot_ok], successV[plot_ok], nrpoints=Inf, pch=20, col=transp("black"),
                   ylim=c(0,1), xlab="Number of PCA axes retained",
                   ylab="Proportion of successful outcome prediction", 
                   main="DAPC Cross-Validation")
+    } else {
+      plot(xval$n.pca[plot_ok], successV[plot_ok], pch=20,
+           ylim=c(0,1), xlab="Number of PCA axes retained",
+           ylab="Proportion of successful outcome prediction",
+           main="DAPC Cross-Validation")
+    }
     abline(h=q.phen, lty=c(2,1,2))
   }
   
@@ -281,4 +315,3 @@ xvalDapc.genlight <- function(x, ...){
 xvalDapc.genind <- function(x, ...){
   xvalDapc.matrix(tab(x), ...)
 }
-

--- a/man/xvalDapc.Rd
+++ b/man/xvalDapc.Rd
@@ -89,8 +89,10 @@ xvalDapc(x, \dots)
     the selected PC count and the requested \code{center}, \code{scale},
     and \code{n.da} settings.
 
-    A PC count unsupported by the rank of any of its training splits is
-    excluded from selection, with a warning. Such replicates have
+    A PC count unsupported by the PCA rank or the pooled within-group
+    LDA rank of any training split is excluded from selection, with a
+    warning. The latter is at most \eqn{N-K}, for \eqn{N} training
+    individuals in \eqn{K} represented groups. Such replicates have
     \code{NA} success, and the candidate's mean success and RMSE are
     \code{NA}; they are not silently evaluated using fewer PCs.
     If no candidate remains, reduce the requested PC counts.

--- a/man/xvalDapc.Rd
+++ b/man/xvalDapc.Rd
@@ -36,7 +36,10 @@ xvalDapc(x, \dots)
 \method{xvalDapc}{genind}(x, \dots)
 }
 \arguments{
-  \item{x}{\code{a data.frame} or a \code{matrix} used as input of DAPC.}
+  \item{x}{A numeric \code{data.frame} or \code{matrix}, or a
+    \linkS4class{genind} or \linkS4class{genlight} object. Values must be
+    finite and complete; missing values are not imputed. The genetic-object
+    methods convert to allele counts or SNP dosages, respectively.}
   \item{grp}{a \code{factor} indicating the group membership of
     individuals.}
   \item{n.pca.max}{maximum number of PCA components to retain.}
@@ -50,7 +53,8 @@ xvalDapc(x, \dots)
   \item{result}{a character string; "groupMean" for group-wise assignment
     sucess, or  "overall" for an overall mean assignment success; see details.}
   \item{center}{a \code{logical} indicating whether variables should be centred to
-    mean 0 (TRUE, default) or not (FALSE). Always TRUE for \linkS4class{genind} objects.}
+    mean 0 (TRUE, default) or not (FALSE). Centring is fitted separately
+    within each training split.}
   \item{scale}{a \code{logical} indicating whether variables should be scaled
     (TRUE) or not (FALSE, default). Scaling consists in dividing variables by their
     (estimated) standard deviation to account for trivial differences in
@@ -76,6 +80,40 @@ xvalDapc(x, \dots)
   (result="groupMean"), or the overall prediction success (result="overall").
   The number of PCs associated with the lowest Mean Squared Error is then
   retained in the DAPC.
+  \subsection{Training-only preprocessing}{
+    Each replicate fits PCA, including centring and scaling, using only
+    the training individuals. Validation individuals are projected using
+    that training transformation before their memberships are predicted.
+    No PCA fitted to the full dataset is used to score validation samples.
+    The final returned DAPC is then fitted to all input individuals, using
+    the selected PC count and the requested \code{center}, \code{scale},
+    and \code{n.da} settings.
+
+    A PC count unsupported by the rank of any of its training splits is
+    excluded from selection, with a warning. Such replicates have
+    \code{NA} success, and the candidate's mean success and RMSE are
+    \code{NA}; they are not silently evaluated using fewer PCs.
+    If no candidate remains, reduce the requested PC counts.
+    Singleton groups remain in training and cannot be evaluated in
+    validation. Every other group contributes at least one individual to
+    each set.
+  }
+  \subsection{Missing data and interpretation}{
+    Missing values cause an explicit error. Unlike \code{dapc.genind},
+    this function does not automatically replace them with allele means.
+    Imputing the full dataset before cross-validation can allow validation
+    individuals to influence training preprocessing. To evaluate an
+    imputation-plus-DAPC workflow, imputation must also be fitted within
+    each training split; this function does not currently implement that
+    workflow. Mean replacement does not propagate genotype uncertainty.
+
+    These cross-validation results select the PC count; they are not an
+    independent performance estimate for that selected model. Independent
+    test data or an outer validation loop are needed for that purpose.
+    Splits are stratified by group, not blocked by sequencing batch,
+    family, or collection site. Strong assignment alone therefore does
+    not rule out technical or sampling confounding.
+  }
   \subsection{Parallel Computing}{
     The permutation of the data for cross-validation is performed in part by the
     function\code{\link[boot]{boot}}. If you have a modern computer, it is

--- a/tests/testthat/test-xval-training-pca.R
+++ b/tests/testthat/test-xval-training-pca.R
@@ -66,6 +66,18 @@ test_that("rank-infeasible candidates are not scored under a false PC count", {
                           n.rep = 2, xval.plot = FALSE), "No candidate")
 })
 
+test_that("PC candidates respect the training within-group LDA rank", {
+    set.seed(107)
+    x <- matrix(rnorm(30 * 40), 30, 40)
+    grp <- factor(rep(c("A", "B", "C"), each = 10))
+    # With 21 training individuals in 3 groups, pooled within-group
+    # covariance has rank at most 18, even though PCA supports 20 axes.
+    ans <- xvalDapc(x, grp, n.pca = c(18, 19, 20), n.pca.max = 20,
+                    training.set = 0.7, n.rep = 1, xval.plot = FALSE)
+    expect_equal(unique(ans[[1]]$n.pca), 18)
+    expect_lte(ans$DAPC$n.pca, 18)
+})
+
 test_that("missing data are rejected explicitly and splits retain groups", {
     x <- matrix(seq_len(40), 10, 4)
     x[1, 1] <- NA

--- a/tests/testthat/test-xval-training-pca.R
+++ b/tests/testthat/test-xval-training-pca.R
@@ -1,0 +1,81 @@
+test_that("validation individuals do not contribute to PCA or DAPC fits", {
+    set.seed(104)
+    x <- matrix(rnorm(48 * 6), 48, 6)
+    grp <- factor(rep(c("A", "B", "C"), each = 16))
+    keep <- unlist(lapply(split(seq_len(48), grp), head, 10))
+    dat <- list(DATA = x, GRP = grp, KEEP = keep,
+                CENTER = TRUE, SCALE = TRUE)
+    # Instrument a private copy so this test does not modify the namespace.
+    worker <- adegenet:::.boot_dapc_pred
+    env <- new.env(parent = environment(worker))
+    seen <- list()
+    fits <- 0L
+    env$dudi.pca <- function(df, ...) {
+        seen[[length(seen) + 1L]] <<- df
+        ade4::dudi.pca(df, ...)
+    }
+    env$dapc <- function(...) {
+        fits <<- fits + 1L
+        adegenet::dapc(...)
+    }
+    environment(worker) <- env
+    answer <- worker(dat, n.pca = 2, n.da = 1)
+    expect_length(seen, 1)
+    expect_equal(seen[[1]], x[keep, , drop = FALSE])
+    expect_equal(fits, 1L)
+    reference <- dapc(x[keep, ], grp[keep], n.pca = 2, n.da = 1,
+                      center = TRUE, scale = TRUE)
+    expected <- mean(predict(reference, x[-keep, ])$assign == grp[-keep])
+    expect_equal(answer, expected)
+    dat$DATA[-keep, ] <- dat$DATA[-keep, ] + 1000
+    worker(dat, n.pca = 2, n.da = 1)
+    expect_equal(seen[[2]], seen[[1]])
+})
+
+test_that("final DAPC preserves requested preprocessing and n.da", {
+    set.seed(105)
+    x <- matrix(rnorm(60 * 6), 60, 6)
+    x <- sweep(x, 2, seq_len(6), "*") + 10
+    grp <- factor(rep(c("A", "B", "C"), each = 20))
+    ans <- xvalDapc(x, grp, n.pca = 2, n.pca.max = 2, n.da = 1,
+                    training.set = 0.7, center = FALSE, scale = TRUE,
+                    n.rep = 1, xval.plot = FALSE)
+    reference <- dapc(x, grp, n.pca = 2, n.da = 1,
+                      center = FALSE, scale = TRUE)
+    expect_equal(ans$DAPC$pca.cent, reference$pca.cent)
+    expect_equal(ans$DAPC$pca.norm, reference$pca.norm)
+    expect_equal(ans$DAPC$n.da, 1)
+    expect_equal(ans$DAPC$posterior, reference$posterior)
+    expect_equal(nrow(ans[[1]]), 1L)
+    expect_equal(as.numeric(ans[[5]]), abs(ans[[1]]$success - 1))
+})
+
+test_that("rank-infeasible candidates are not scored under a false PC count", {
+    set.seed(106)
+    z <- rnorm(60)
+    x <- cbind(locus1 = z, locus2 = z, locus3 = z)
+    grp <- factor(rep(c("A", "B"), each = 30))
+    expect_warning(ans <- xvalDapc(x, grp, n.pca = c(1, 2),
+                                   n.pca.max = 2, n.rep = 2,
+                                   xval.plot = FALSE), "excluded")
+    expect_true(all(is.na(ans[[1]]$success[ans[[1]]$n.pca == 2])))
+    expect_equal(ans$DAPC$n.pca, 1)
+    expect_true(is.na(ans[[3]]["2"]))
+    expect_true(is.na(ans[[5]]["2"]))
+    expect_error(xvalDapc(x, grp, n.pca = 2, n.pca.max = 2,
+                          n.rep = 2, xval.plot = FALSE), "No candidate")
+})
+
+test_that("missing data are rejected explicitly and splits retain groups", {
+    x <- matrix(seq_len(40), 10, 4)
+    x[1, 1] <- NA
+    expect_error(xvalDapc(x, rep(1:2, each = 5)), "missing values are not imputed")
+    grp <- factor(c("singleton", rep("A", 3), rep("B", 4)))
+    for (fraction in c(0.01, 0.99)) {
+        keep <- unlist(lapply(levels(grp), adegenet:::.group_sampler,
+                               grp = grp, training.set = fraction))
+        expect_true(1L %in% keep)
+        expect_equal(length(unique(grp[keep])), 3L)
+        expect_equal(length(unique(grp[-keep])), 2L)
+    }
+})


### PR DESCRIPTION
## Summary

Fit PCA within each training split in `xvalDapc()`, rather than fitting it
to the full dataset and subsetting its scores. Also remove a duplicate
model fit and preserve the requested preprocessing and `n.da` settings
when fitting the final returned DAPC.

## Context

Hi Thibaut and Zhian,

Following the prediction-time missing-value investigation in #375, I
looked at how the cross-validation workflow separates training and
validation information.

The current implementation fits PCA to all individuals before sampling
the training sets. The resampling helper then subsets only the rows of
the PCA scores. Consequently, validation individuals influence the PCA
centres, scales, and axes used in their evaluation.

This is unsupervised preprocessing leakage, not leakage of group labels.
It does not establish that every reported accuracy is inflated. However,
it differs from a held-out evaluation of the complete PCA-plus-DA pipeline.
This PR makes that distinction explicit and fits the preprocessing within
each training split.

## Changes

- Fit PCA to training rows only and project validation rows with that
  training transformation.
- Fit DAPC once per replicate, removing the immediately discarded first fit.
- Preserve `center`, `scale`, and `n.da` in the final full-data model.
- Bound PC candidates using actual stratified training-set sizes and the
  pooled within-group LDA rank limit, at most `N - K`, and include feasible
  boundary values.
- Exclude a PC candidate from selection if any of its training splits
  cannot support that count. Record `NA` for rank-infeasible replicates,
  warn, and retain those rows for inspection rather than silently
  evaluating fewer PCs under the requested label.
- Simplify RMSE aggregation so a single replicate or PC candidate works.
- Keep non-singleton groups represented in both subsets and reject
  datasets with no possible validation individuals.
- Give an explicit missing-data error rather than silently introducing
  an imputation strategy.
- Handle degenerate plotting grids with an ordinary scatterplot.

## Missing data and interpretation

This PR does **not** add imputation. Complete finite input remains required.
The documentation explains that imputing all samples before splitting
can itself introduce validation information into preprocessing. Evaluating
an imputation-plus-DAPC pipeline requires fitting imputation within each
training split; that workflow is not implemented here.

The documentation also distinguishes PC selection from independent
performance evaluation and notes that group-stratified sampling does not
block sequencing batches, families, or collection sites.

## Validation

Focused tests verify training-only PCA inputs, one DAPC fit per replicate,
agreement with a manually fitted training-only reference, invariance of
training inputs to changes in held-out values, preservation of final-model
settings, PCA- and LDA-rank-infeasible candidates, missing-data rejection, and group
representation in splits.

- 26 new checks passed.
- 5 checks in the existing `test_xval.R` passed.
- Serial, snow, and multicore smoke tests passed on macOS.
- The updated Rd file parsed successfully.

These are source-level checks with adegenet 2.1.11 dependencies in isolated
R processes, not a full package build/check or a Windows execution test.
The test harness substitutes the updated internal helpers only within
the test process; it does not modify the installed package files.

## Compatibility and trade-offs

The public argument list and seven-item result layout are retained.
Cross-validation values and selected PC counts may change by design.
PCA is recomputed per replicate, which costs more than reusing a full-data
PCA; removing the duplicate DAPC fit offsets some work but is not a promise
of a net speedup. Rank-infeasible candidates are explicitly flagged.

This change does not depend on #375: cross-validation uses numeric
matrices, not prediction-time conversion of new `genind` objects.
