### PR TITLE
Safeguard DAPC against singular within-group covariance

### DIFF
--- a/R/dapc.R
+++ b/R/dapc.R
@@ -3,6 +3,30 @@
 ########
 dapc <- function (x, ...) UseMethod("dapc")
 
+
+# Return the largest leading set of PCA scores whose pooled within-group
+# residual matrix is numerically full rank. LDA requires this covariance
+# structure to be invertible.
+.dapc_full_rank_prefix <- function(scores, grp,
+                                   tol = sqrt(.Machine$double.eps)) {
+    grp <- droplevels(as.factor(grp))
+    residuals <- scores
+    for (group in levels(grp)) {
+        rows <- which(grp == group)
+        residuals[rows, ] <- sweep(scores[rows, , drop = FALSE], 2,
+                                   colMeans(scores[rows, , drop = FALSE]),
+                                   "-")
+    }
+    for (k in rev(seq_len(ncol(residuals)))) {
+        singular <- svd(residuals[, seq_len(k), drop = FALSE],
+                        nu = 0, nv = 0)$d
+        rank <- if (!length(singular) || singular[1] == 0) 0L else
+            sum(singular > singular[1] * tol)
+        if (rank == k) return(k)
+    }
+    0L
+}
+
 ###################
 ## dapc.data.frame
 ###################
@@ -13,7 +37,7 @@ dapc.data.frame <- function(x, grp, n.pca=NULL, n.da=NULL,
                             pca.info=TRUE, pca.select=c("nbEig","percVar"), perc.pca=NULL, ..., dudi=NULL){
 
     ## FIRST CHECKS
-    grp <- as.factor(grp)
+    grp <- droplevels(as.factor(grp))
     if(length(grp) != nrow(x)) stop("Inconsistent length for grp")
     pca.select <- match.arg(pca.select)
     if(!is.null(perc.pca) & is.null(n.pca)) pca.select <- "percVar"
@@ -64,19 +88,35 @@ dapc.data.frame <- function(x, grp, n.pca=NULL, n.da=NULL,
     ## keep relevant PCs - stored in XU
     X.rank <- sum(pcaX$eig > 1e-14)
     n.pca <- min(X.rank, n.pca)
-    if(n.pca >= N) n.pca <- N-1
+    requested.n.pca <- n.pca
+    n.pca <- min(n.pca, N - nlevels(grp))
+    if (n.pca < requested.n.pca)
+        warning("Reducing n.pca from ", requested.n.pca, " to ", n.pca,
+                " because pooled within-group covariance rank is at most N - K.")
+    if (n.pca < 1L)
+        stop("Too few within-group residual degrees of freedom for DAPC.")
     n.pca <- round(n.pca)
 
-    U <- pcaX$c1[, 1:n.pca, drop=FALSE] # principal axes
-    rownames(U) <- colnames(x) # force to restore names
     XU <- pcaX$li[, 1:n.pca, drop=FALSE] # principal components
+    full.rank <- .dapc_full_rank_prefix(XU, grp)
+    if (full.rank < 1L)
+        stop("PCA scores are numerically constant within groups; ",
+             "a discriminant model cannot be fitted.")
+    if (full.rank < n.pca) {
+        warning("Reducing n.pca from ", n.pca, " to ", full.rank,
+                " because the pooled within-group covariance is rank deficient.")
+        n.pca <- full.rank
+        XU <- XU[, seq_len(n.pca), drop = FALSE]
+    }
+    U <- pcaX$c1[, seq_len(n.pca), drop=FALSE] # principal axes
+    rownames(U) <- colnames(x) # force to restore names
     XU.lambda <- sum(pcaX$eig[1:n.pca])/sum(pcaX$eig) # sum of retained eigenvalues
     names(U) <- paste("PCA-pa", 1:ncol(U), sep=".")
     names(XU) <- paste("PCA-pc", 1:ncol(XU), sep=".")
 
 
     ## PERFORM DA ##
-    ldaX <- lda(XU, grp, tol=1e-30) # tol=1e-30 is a kludge, but a safe (?) one to avoid fancy rescaling by lda.default
+    ldaX <- lda(XU, grp, tol=sqrt(.Machine$double.eps))
     lda.dim <- sum(ldaX$svd^2 > 1e-10)
     ldaX$svd <- ldaX$svd[1:lda.dim]
     ldaX$scaling <- ldaX$scaling[,1:lda.dim,drop=FALSE]
@@ -88,7 +128,7 @@ dapc.data.frame <- function(x, grp, n.pca=NULL, n.da=NULL,
     }
 
     ##n.da <- min(n.da, length(levels(grp))-1, n.pca) # can't be more than K-1 disc. func., or more than n.pca
-    n.da <- round(min(n.da, lda.dim)) # can't be more than K-1 disc. func., or more than n.pca
+    n.da <- round(min(n.da, nlevels(grp) - 1L, n.pca, lda.dim))
     predX <- predict(ldaX, dimen=n.da)
 
 
@@ -172,6 +212,7 @@ dapc.genind <- function(x, pop=NULL, n.pca=NULL, n.da=NULL,
     }
 
     if(is.null(pop.fac)) stop("x does not include pre-defined populations, and `pop' is not provided")
+    pop.fac <- droplevels(as.factor(pop.fac))
 
 
     ## SOME GENERAL VARIABLES
@@ -243,6 +284,7 @@ dapc.genlight <- function(x, pop=NULL, n.pca=NULL, n.da=NULL,
 
     ## PERFORM PCA ##
     REDUCEDIM <- is.null(glPca)
+    need.loadings <- var.contrib || var.loadings || pca.info
 
     if(REDUCEDIM){ # if no glPca provided
         maxRank <- min(c(nInd(x), nLoc(x)))
@@ -250,10 +292,6 @@ dapc.genlight <- function(x, pop=NULL, n.pca=NULL, n.da=NULL,
     }
 
     if(!REDUCEDIM){ # else use the provided glPca object
-        if(is.null(glPca$loadings) & var.contrib) {
-            warning("Contribution of variables requested but glPca object provided without loadings.")
-            var.contrib <- FALSE
-        }
         pcaX <- glPca
     }
 
@@ -296,8 +334,9 @@ dapc.genlight <- function(x, pop=NULL, n.pca=NULL, n.da=NULL,
 
 
     ## recompute PCA with loadings if needed
-    if(REDUCEDIM){
-        pcaX <- glPca(x, center = TRUE, scale = scale, nf=n.pca, loadings=var.contrib, matDotProd = pcaX$dotProd)
+    if(REDUCEDIM || (need.loadings && is.null(pcaX$loadings))){
+        pcaX <- glPca(x, center = TRUE, scale = scale, nf=n.pca,
+                      loadings=need.loadings, matDotProd = pcaX$dotProd)
     }
 
 
@@ -305,17 +344,34 @@ dapc.genlight <- function(x, pop=NULL, n.pca=NULL, n.da=NULL,
     N <- nInd(x)
     X.rank <- sum(pcaX$eig > 1e-14)
     n.pca <- min(X.rank, n.pca)
-    if(n.pca >= N) n.pca <- N-1
+    requested.n.pca <- n.pca
+    n.pca <- min(n.pca, N - nlevels(pop.fac))
+    if (n.pca < requested.n.pca)
+        warning("Reducing n.pca from ", requested.n.pca, " to ", n.pca,
+                " because pooled within-group covariance rank is at most N - K.")
+    if (n.pca < 1L)
+        stop("Too few within-group residual degrees of freedom for DAPC.")
 
-    U <- pcaX$loadings[, 1:n.pca, drop=FALSE] # principal axes
     XU <- pcaX$scores[, 1:n.pca, drop=FALSE] # principal components
+    full.rank <- .dapc_full_rank_prefix(XU, pop.fac)
+    if (full.rank < 1L)
+        stop("PCA scores are numerically constant within groups; ",
+             "a discriminant model cannot be fitted.")
+    if (full.rank < n.pca) {
+        warning("Reducing n.pca from ", n.pca, " to ", full.rank,
+                " because the pooled within-group covariance is rank deficient.")
+        n.pca <- full.rank
+        XU <- XU[, seq_len(n.pca), drop = FALSE]
+    }
+    U <- if (need.loadings)
+        pcaX$loadings[, seq_len(n.pca), drop=FALSE] else NULL
     XU.lambda <- sum(pcaX$eig[1:n.pca])/sum(pcaX$eig) # sum of retained eigenvalues
-    names(U) <- paste("PCA-pa", 1:ncol(U), sep=".")
+    if (!is.null(U)) names(U) <- paste("PCA-pa", seq_len(ncol(U)), sep=".")
     names(XU) <- paste("PCA-pc", 1:ncol(XU), sep=".")
 
 
     ## PERFORM DA ##
-    ldaX <- lda(XU, pop.fac, tol=1e-30) # tol=1e-30 is a kludge, but a safe (?) one to avoid fancy rescaling by lda.default
+    ldaX <- lda(XU, pop.fac, tol=sqrt(.Machine$double.eps))
     lda.dim <- sum(ldaX$svd^2 > 1e-10)
     ldaX$svd <- ldaX$svd[1:lda.dim]
     ldaX$scaling <- ldaX$scaling[,1:lda.dim,drop=FALSE]

--- a/man/dapc.Rd
+++ b/man/dapc.Rd
@@ -151,6 +151,27 @@
 
   DAPC does not infer genetic clusters ex nihilo; for this, see the
   \code{\link{find.clusters}} function.
+
+  The discriminant step requires a nonsingular pooled within-group
+  covariance matrix. For \eqn{N} individuals in \eqn{K} represented
+  groups, its rank is at most \eqn{N-K}. Accordingly, \code{dapc}
+  reduces \code{n.pca} when it exceeds this bound or when the leading
+  PCA scores are numerically rank deficient within groups, and reports
+  the reduction with a warning. If even the first PCA score is
+  numerically constant within groups, no discriminant model is defined
+  and the function stops. Unused levels in \code{grp} or \code{pop}
+  are dropped before fitting and do not count as represented groups.
+
+  A high in-sample assignment rate, particularly when many PCA axes are
+  retained relative to the number of individuals, is not evidence of
+  out-of-sample predictive performance. Use \code{\link{xvalDapc}} to
+  select the number of retained axes and independent data or an outer
+  validation loop when estimating predictive performance.
+
+  For \linkS4class{genlight} input, PCA loadings are computed whenever
+  \code{pca.info}, \code{var.contrib}, or \code{var.loadings} requires
+  them. Thus, disabling variable contributions does not remove the
+  loadings needed by \code{predict.dapc} when \code{pca.info=TRUE}.
 }
 \value{
   === dapc objects ===\cr

--- a/tests/testthat/test-dapc-within-group-rank.R
+++ b/tests/testthat/test-dapc-within-group-rank.R
@@ -1,0 +1,64 @@
+test_that("DAPC respects the pooled within-group rank bound", {
+    set.seed(302)
+    x <- matrix(rnorm(30 * 200), 30, 200,
+                dimnames = list(NULL, paste0("v", seq_len(200))))
+    grp <- factor(rep(c("A", "B", "C"), each = 10))
+    expect_warning(fit <- dapc(x, grp, n.pca = 29, n.da = 2),
+                   "N - K")
+    expect_equal(fit$n.pca, 27)
+    expect_equal(fit$n.da, 2)
+    expect_true(all(is.finite(fit$posterior)))
+    expect_lt(max(fit$eig), 1e10)
+    expect_lt(max(abs(fit$loadings)), 1e6)
+})
+
+test_that("DAPC reduces data-specific within-group rank deficiency", {
+    set.seed(303)
+    grp <- factor(rep(c("A", "B", "C"), each = 10))
+    signal <- rep(c(0, 1, 2), each = 10)
+    x <- cbind(nuisance = rnorm(30), signal = signal)
+    expect_warning(fit <- dapc(x, grp, n.pca = 2, n.da = 2),
+                   "rank deficient")
+    expect_equal(fit$n.pca, 1)
+    expect_equal(fit$n.da, 1)
+    expect_true(all(is.finite(fit$posterior)))
+
+    expect_error(dapc(matrix(signal, ncol = 1,
+                             dimnames = list(NULL, "signal")),
+                      grp, n.pca = 1, n.da = 1),
+                 "constant within groups")
+})
+
+test_that("unused group levels do not alter DAPC dimensions", {
+    set.seed(304)
+    x <- matrix(rnorm(90), 30, 3,
+                dimnames = list(NULL, paste0("v", 1:3)))
+    grp <- factor(rep(c("A", "B", "C"), each = 10),
+                  levels = c("A", "B", "C", "ghost"))
+    fit <- dapc(x, grp, n.pca = 3, n.da = 4)
+    expect_equal(levels(fit$grp), c("A", "B", "C"))
+    expect_equal(fit$n.da, 2)
+    expect_equal(ncol(fit$posterior), 3)
+})
+
+test_that("genlight DAPC applies the same rank safeguards", {
+    set.seed(305)
+    dosage <- matrix(sample(0:2, 30 * 40, replace = TRUE), 30, 40)
+    gl <- new("genlight", dosage)
+    pop(gl) <- factor(rep(c("A", "B", "C"), each = 10),
+                      levels = c("A", "B", "C", "ghost"))
+    expect_warning(fit <- dapc(gl, n.pca = 29, n.da = 4,
+                               var.contrib = FALSE), "N - K")
+    expect_equal(fit$n.pca, 27)
+    expect_equal(fit$n.da, 2)
+    expect_equal(levels(fit$grp), c("A", "B", "C"))
+    expect_true(all(is.finite(fit$posterior)))
+    expect_false(is.null(fit$pca.loadings))
+    prediction <- predict(fit, gl[1:3, ])
+    expect_equal(nrow(prediction$posterior), 3)
+
+    lean <- dapc(gl, n.pca = 5, n.da = 2, pca.info = FALSE,
+                 var.contrib = FALSE, var.loadings = FALSE)
+    expect_null(lean$pca.loadings)
+    expect_true(all(is.finite(lean$posterior)))
+})


### PR DESCRIPTION
## Summary

Prevent `dapc()` from fitting a discriminant model when the retained PCA
scores have a singular pooled within-group covariance matrix. Apply the
same safeguards to data-frame/matrix, `genind`, and `genlight` workflows,
and correct loading computation for `genlight` models that retain PCA
information while disabling variable contributions.

## Context

Hi Thibaut and Zhian,

While following the rank safeguards added to cross-validation in #376,
I tested direct DAPC fits with many retained PCs and strongly collinear
within-group scores.

LDA estimates its covariance from deviations around group means. For
`N` individuals in `K` represented groups, that residual matrix has rank
at most `N - K`, rather than the ordinary PCA ceiling of `N - 1`.

The current DAPC implementation passes `tol = 1e-30` to `MASS::lda()`.
That allows numerically singular directions to enter the discriminant fit.
In a stress test with 30 individuals, three arbitrary groups, and random
data, retaining 28 or 29 PCs produced:

- discriminant eigenvalues of approximately `10^31` to `10^35`;
- discriminant loadings of approximately `10^14` to `10^16`;
- posterior probabilities equal to one to displayed precision; and
- 100% in-sample assignment despite random group labels.

This is deliberately a stress test, not an estimate of how often such
fits occur. It demonstrates that the function can return a formally
complete but numerically singular result whose apparent certainty is not
scientifically interpretable.

## Changes

- Drop unused grouping-factor levels before determining group dimensions.
- Bound retained PCs by `N - K` and report reductions.
- Calculate the numerical rank of the pooled within-group residual matrix.
- Retain the largest leading PC prefix that is numerically full rank.
- Stop clearly if even the first PCA score is constant within groups.
- Bound `n.da` by represented groups, retained PCs, and available
  discriminant rank.
- Replace the near-zero LDA tolerance with a numerical tolerance based on
  machine precision after the explicit rank check.
- Apply the same behaviour to `genlight` DAPC.
- Compute `genlight` PCA loadings whenever `pca.info`, `var.contrib`, or
  `var.loadings` requires them.

## Validation

Twenty-three focused checks cover:

- the structural `N - K` rank ceiling;
- data-specific within-group rank deficiency;
- a fully constant-within-group discriminant input;
- unused factor levels and the `K - 1` discriminant-axis ceiling;
- finite eigenvalues, loadings, and posterior probabilities;
- equivalent safeguards for `genlight`;
- prediction from `genlight` when `pca.info = TRUE` and
  `var.contrib = FALSE`; and
- omission of PCA loadings when no requested output requires them.

The original implementation fails the focused regression suite. The
revised implementation passes all 23 checks. Smoke tests using `sim2pop`,
`microbov`, and simulated `genlight` data also pass. The updated Rd file
parses successfully.

These are source-level tests using adegenet 2.1.11 dependencies, not a
complete package build/check or cross-platform numerical validation.

## Compatibility and interpretation

The public argument list and DAPC result structure are unchanged. Fits
that previously used singular directions can now retain fewer PCs or
stop when no discriminant covariance is estimable. This is an intentional
behaviour change; downstream numerical values may change for affected fits.

The documentation also states that in-sample assignment is not an
out-of-sample performance estimate and points users toward cross-validation
for selecting retained PCs.

This provides a concrete safeguard relevant to the `K` versus `K - 1`
discussion in #215, including unused factor levels, without claiming to
reproduce the original private dataset. I have not marked the unrelated
LAPACK convergence report in #214 as fixed because its data are unavailable
and that error may also arise from PCA or linked numerical libraries.