### PR TITLE
Fix dimension handling in optim.a.score

### DIFF
--- a/R/dapc.R
+++ b/R/dapc.R
@@ -820,27 +820,43 @@ a.score <- function(x, n.sim=10, ...){
 ## optim.a.score
 ##############
 optim.a.score <- function(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
-                         n.sim=10, n.da=length(levels(x$grp)), ...){
+                         n.sim=10, n.da=length(levels(x$grp))-1L, ...){
     ## A FEW CHECKS ##
     if(!inherits(x,"dapc")) stop("x is not a dapc object")
-    if(max(n.pca)>ncol(x$tab)) {
-        n.pca <- min(n.pca):ncol(x$tab)
-    }
-    if(n.da>length(levels(x$grp))){
-        n.da <- min(n.da):length(levels(x$grp))
-    }
+    if (!is.numeric(n.pca) || !length(n.pca) || anyNA(n.pca) ||
+        any(!is.finite(n.pca)) || any(n.pca < 1) ||
+        any(n.pca != floor(n.pca)))
+        stop("n.pca must contain positive integers.")
+    if (length(n.pca) == 1L) n.pca <- seq_len(n.pca)
+    n.pca <- sort(unique(as.integer(n.pca)))
+    if (max(n.pca) > ncol(x$tab))
+        stop("n.pca cannot exceed the ", ncol(x$tab),
+             " PCA axes stored in x$tab.")
+    max.da <- length(levels(droplevels(x$grp))) - 1L
+    if (length(n.da) != 1L || !is.numeric(n.da) || is.na(n.da) ||
+        !is.finite(n.da) || n.da < 1 || n.da != floor(n.da) ||
+        n.da > max.da)
+        stop("n.da must be one positive integer no greater than ", max.da,
+             " for these groups and retained PCs.")
+    n.da <- as.integer(n.da)
+    if (!is.logical(smart) || length(smart) != 1L || is.na(smart))
+        stop("smart must be TRUE or FALSE.")
+    if (!is.logical(plot) || length(plot) != 1L || is.na(plot))
+        stop("plot must be TRUE or FALSE.")
+    if (length(n.sim) != 1L || !is.numeric(n.sim) || is.na(n.sim) ||
+        !is.finite(n.sim) || n.sim < 1 || n.sim != floor(n.sim))
+        stop("n.sim must be a positive integer.")
+    if (length(n) != 1L || !is.numeric(n) || is.na(n) ||
+        !is.finite(n) || n < 2 || n != floor(n))
+        stop("n must be an integer of at least 2.")
     pred <- NULL
-    if(length(n.pca)==1){
-        n.pca <- 1:n.pca
-    }
-    if(length(n.da)==1){
-        n.da <- 1:n.da
-    }
 
 
     ## AUXILIARY FUNCTION ##
     f1 <- function(ndim){
-        temp <- dapc(x$tab[,1:ndim,drop=FALSE], x$grp, n.pca=ndim, n.da=x$n.da)
+        retained.da <- min(n.da, ndim)
+        temp <- dapc(x$tab[,1:ndim,drop=FALSE], x$grp,
+                     n.pca=ndim, n.da=retained.da)
         a.score(temp, n.sim=n.sim)$pop.score
     }
 
@@ -850,21 +866,25 @@ optim.a.score <- function(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
         ## if(!require(stats)) stop("the package stats is required for 'smart' option")
         o.min <- min(n.pca)
         o.max <- max(n.pca)
-        n.pca <- pretty(n.pca, n) # get evenly spaced nb of retained PCs
-        n.pca <- n.pca[n.pca>0 & n.pca<=ncol(x$tab)]
+        n.pca <- pretty(range(n.pca), n) # evenly spaced retained PC counts
+        n.pca <- unique(as.integer(n.pca[n.pca>0 &
+                                         n.pca<=ncol(x$tab)]))
         if(!any(o.min==n.pca)) n.pca <- c(o.min, n.pca) # make sure range is OK
         if(!any(o.max==n.pca)) n.pca <- c(o.max, n.pca) # make sure range is OK
+        n.pca <- sort(unique(n.pca))
         lres <- lapply(n.pca, f1)
         names(lres) <- n.pca
         means <- sapply(lres, mean)
         sp1 <- smooth.spline(n.pca, means) # spline smoothing
         pred <- predict(sp1, x=1:max(n.pca))
-        best <- pred$x[which.max(pred$y)]
+        best.index <- which.max(pred$y)
+        best <- pred$x[best.index]
     } else { ## DO NOT TRY TO BE SMART ##
         lres <- lapply(n.pca, f1)
         names(lres) <- n.pca
-        best <- which.max(sapply(lres, mean))
         means <- sapply(lres, mean)
+        best.index <- which.max(means)
+        best <- n.pca[best.index]
     }
 
 
@@ -880,16 +900,16 @@ optim.a.score <- function(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
         if(smart){
             boxplot(lres, at=n.pca, col="gold", xlab="Number of retained PCs", ylab="a-score", xlim=range(n.pca)+c(-1,1), ylim=c(-.1,1.1))
             lines(pred, lwd=3)
-            points(pred$x[best], pred$y[best], col="red", lwd=3)
+            points(pred$x[best.index], pred$y[best.index], col="red", lwd=3)
             title("a-score optimisation - spline interpolation")
             mtext(paste("Optimal number of PCs:", res$best), side=3)
         } else {
             myCol <- rep("gold", length(lres))
-            myCol[best] <- "red"
+            myCol[best.index] <- "red"
             boxplot(lres, at=n.pca, col=myCol, xlab="Number of retained PCs", ylab="a-score", xlim=range(n.pca)+c(-1,1), ylim=c(-.1,1.1))
             lines(n.pca, sapply(lres, mean), lwd=3, type="b")
             myCol <- rep("black", length(lres))
-            myCol[best] <- "red"
+            myCol[best.index] <- "red"
             points(n.pca, res$mean, lwd=3, col=myCol)
             title("a-score optimisation - basic search")
             mtext(paste("Optimal number of PCs:", res$best), side=3)

--- a/R/dapc.R
+++ b/R/dapc.R
@@ -820,7 +820,7 @@ a.score <- function(x, n.sim=10, ...){
 ## optim.a.score
 ##############
 optim.a.score <- function(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
-                         n.sim=10, n.da=length(levels(x$grp))-1L, ...){
+                         n.sim=10, n.da=x$n.da, ...){
     ## A FEW CHECKS ##
     if(!inherits(x,"dapc")) stop("x is not a dapc object")
     if (!is.numeric(n.pca) || !length(n.pca) || anyNA(n.pca) ||

--- a/man/ascore.Rd
+++ b/man/ascore.Rd
@@ -11,7 +11,7 @@
 a.score(x, n.sim=10, \ldots)
 
 optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
-              n.sim=10, n.da=length(levels(x$grp))-1L, \ldots)
+              n.sim=10, n.da=x$n.da, \ldots)
 }
 \arguments{
 \item{x}{a \code{dapc} object.}
@@ -31,7 +31,9 @@ optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
 \item{n.da}{one positive \code{integer} indicating the maximum number of axes
   retained in each Discriminant Analysis step. It cannot exceed the number of
   groups minus one. When fewer PCA axes are being evaluated, the number of
-  discriminant axes is limited to the number of retained PCA axes.}
+  discriminant axes is limited to the number of retained PCA axes. The default
+  uses the number retained in the supplied DAPC object, preserving the
+  historical behaviour when this argument is omitted.}
 \item{\ldots}{further arguments passed to other methods; currently unused..}
 }
 \details{

--- a/man/ascore.Rd
+++ b/man/ascore.Rd
@@ -11,7 +11,7 @@
 a.score(x, n.sim=10, \ldots)
 
 optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
-              n.sim=10, n.da=length(levels(x$grp)), \ldots)
+              n.sim=10, n.da=length(levels(x$grp))-1L, \ldots)
 }
 \arguments{
 \item{x}{a \code{dapc} object.}
@@ -28,8 +28,10 @@ optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
   displayed graphically (TRUE, default) or not (FALSE).}
 \item{n.sim}{an \code{integer} indicating the number of simulations to
   be performed for each number of retained PC.}
-\item{n.da}{an \code{integer} indicating the number of axes retained in the
-  Discriminant Analysis step.}
+\item{n.da}{one positive \code{integer} indicating the maximum number of axes
+  retained in each Discriminant Analysis step. It cannot exceed the number of
+  groups minus one. When fewer PCA axes are being evaluated, the number of
+  discriminant axes is limited to the number of retained PCA axes.}
 \item{\ldots}{further arguments passed to other methods; currently unused..}
 }
 \details{
@@ -50,6 +52,14 @@ optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
   discriminating and stable, while low values (toward 0 or lower)
   indicate either weak discrimination or instability of the results.
 
+  The a-score is based on reassignment of the observations used to fit the
+  DAPC, corrected by repeating that procedure after permuting group labels. It
+  is not an estimate of predictive performance on held-out individuals and is
+  not a substitute for cross-validation when out-of-sample classification is
+  the scientific objective. Because the permutations and k-means-related
+  computations use random numbers, call \code{set.seed} before
+  \code{optim.a.score} when reproducibility is required.
+
   The a-score can serve as a criterion for choosing the optimal number of
   PCs in the PCA step of DAPC, i.e. the number of PC maximizing the
   a-score. Two procedures are implemented in \code{optim.a.score}. The
@@ -57,9 +67,12 @@ optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
   pre-defined range, compute the a-score for each, and then interpolate
   the results using splines, predicting an approximate optimal number of
   PCs. The other procedure (when \code{smart} is FALSE) performs the
-  computations for all number of PCs request by the user. The 'optimal'
+  computations for all numbers of PCs requested by the user. The 'optimal'
   number is then the one giving the highest mean a-score (computed over
-  the groups).
+  the groups). For the exhaustive procedure, \code{best} is one of the actual
+  values supplied in \code{n.pca}, including when the candidate values are not
+  consecutive. The requested \code{n.da} is applied to every candidate fit,
+  subject to the dimensional limit described above.
 }
 \value{
   === a.score ===\cr
@@ -69,7 +82,7 @@ optim.a.score(x, n.pca=1:ncol(x$tab), smart=TRUE, n=10, plot=TRUE,
   \item{mean}{the overall mean a-score.}\cr
   
   === optim.a.score ===\cr
-  \code{optima.score} returns a list with the following components:\cr
+  \code{optim.a.score} returns a list with the following components:\cr
    \item{pop.score}{a list giving the mean a-score of the populations
    for each number of retained PC (each element of the list corresponds
    to a number of retained PCs).}

--- a/tests/testthat/test-optim-a-score.R
+++ b/tests/testthat/test-optim-a-score.R
@@ -1,0 +1,48 @@
+test_that("optim.a.score returns values from a non-consecutive PC grid", {
+    set.seed(901)
+    grp <- factor(rep(LETTERS[1:3], each = 40))
+    predictors <- matrix(rnorm(120 * 8), 120, 8)
+    predictors[, 1:3] <- predictors[, 1:3] + as.integer(grp) * 0.35
+    fit <- dapc(predictors, grp, n.pca = 8, n.da = 2)
+
+    set.seed(1)
+    result <- optim.a.score(fit, n.pca = c(2, 5, 6), smart = FALSE,
+                            n.sim = 3, n.da = 2, plot = FALSE)
+
+    expect_equal(result$best, 6)
+    expect_true(result$best %in% c(2, 5, 6))
+    expect_named(result$mean, c("2", "5", "6"))
+})
+
+test_that("optim.a.score applies the requested discriminant dimension", {
+    set.seed(902)
+    grp <- factor(rep(LETTERS[1:3], each = 35))
+    predictors <- matrix(rnorm(105 * 6), 105, 6)
+    predictors[, 1:2] <- predictors[, 1:2] + as.integer(grp) * 0.4
+    fit <- dapc(predictors, grp, n.pca = 6, n.da = 2)
+
+    set.seed(903)
+    one.axis <- optim.a.score(fit, n.pca = c(2, 4, 6), smart = FALSE,
+                              n.sim = 4, n.da = 1, plot = FALSE)
+    set.seed(903)
+    two.axes <- optim.a.score(fit, n.pca = c(2, 4, 6), smart = FALSE,
+                              n.sim = 4, n.da = 2, plot = FALSE)
+
+    expect_false(isTRUE(all.equal(one.axis$mean, two.axes$mean)))
+})
+
+test_that("optim.a.score validates dimensions and controls", {
+    fit <- dapc(iris[, 1:4], iris$Species, n.pca = 4, n.da = 2)
+
+    expect_error(optim.a.score(fit, n.pca = c(2, 5), plot = FALSE),
+                 "cannot exceed")
+    expect_error(optim.a.score(fit, n.pca = c(1, 2), n.da = 3,
+                               plot = FALSE),
+                 "n.da must be")
+    expect_error(optim.a.score(fit, n.pca = c(1, 2), n.sim = 0,
+                               plot = FALSE),
+                 "n.sim must be")
+    expect_error(optim.a.score(fit, n.pca = c(1, 2), smart = NA,
+                               plot = FALSE),
+                 "smart must be")
+})

--- a/tests/testthat/test-optim-a-score.R
+++ b/tests/testthat/test-optim-a-score.R
@@ -29,6 +29,11 @@ test_that("optim.a.score applies the requested discriminant dimension", {
                               n.sim = 4, n.da = 2, plot = FALSE)
 
     expect_false(isTRUE(all.equal(one.axis$mean, two.axes$mean)))
+
+    set.seed(903)
+    omitted <- optim.a.score(fit, n.pca = c(2, 4, 6), smart = FALSE,
+                             n.sim = 4, plot = FALSE)
+    expect_equal(omitted$mean, two.axes$mean)
 })
 
 test_that("optim.a.score validates dimensions and controls", {


### PR DESCRIPTION
## Summary

This PR fixes two cases where `optim.a.score()` reports or evaluates a model other than the one requested by the user:

1. With `smart = FALSE`, `best` was the position of the best result in the candidate vector rather than the corresponding number of retained PCs.
2. The `n.da` argument was ignored because every candidate DAPC was fitted with `x$n.da` instead.

It also validates the dimensional and simulation controls and clarifies what the a-score does, **and does not**, measure.

## Sparse PC grids returned the wrong quantity

Testing a sparse PC grid is a realistic way to control computation in genomic analyses. For example, a user may evaluate `n.pca = c(2, 5, 6)` rather than every intermediate dimension.

The exhaustive branch previously used:

```r
best <- which.max(sapply(lres, mean))
```

If 6 PCs produced the largest mean a-score, `which.max()` returned `3` because 6 was the third candidate. The result therefore claimed that 3 PCs were optimal even though 3 PCs had never been evaluated.

In the regression example, 120 individuals from three moderately separated groups are analysed with eight predictor axes. With a fixed random seed, the mean a-score is largest for 6 PCs among the candidate set `c(2, 5, 6)`. The current implementation returns `best = 3`; the corrected implementation returns `best = 6`, which is an actual evaluated candidate.

The plotting code now uses a separate index for highlighting, while the public `best` result contains the scientific quantity represented on the x-axis.

## `n.da` did not control the candidate models

The auxiliary fit was previously constructed with:

```r
dapc(..., n.da = x$n.da)
```

Consequently, changing `n.da` in `optim.a.score()` had no effect. A user could request a one-axis sensitivity analysis and unknowingly receive results using the number of discriminant axes stored in the original DAPC object.

The candidate fits now use the supplied `n.da`. It must be one positive integer no larger than the number of groups minus one. When omitted, it defaults to `x$n.da`, preserving the historical effective behaviour for existing calls. When a candidate model contains fewer PCA axes, its discriminant dimension is necessarily limited to that candidate’s PCA dimension. Fixed-seed regression tests confirm that one- and two-axis requests now evaluate different models and that omission matches an explicit request for `x$n.da`.


## Interpretation and validation

The documentation now states explicitly that a-score is based on in-sample reassignment corrected through permutations of group labels. It is not held-out prediction and should not be presented as a substitute for cross-validation when prediction for new individuals is the objective.

The function now also rejects:

- non-positive, fractional, missing, or non-finite PC counts;
- PC counts exceeding the axes stored in `x$tab`;
- invalid or infeasible discriminant dimensions;
- invalid simulation counts; and
- missing or non-logical `smart` and `plot` controls.

Single values of `n.pca` retain the documented historical meaning of searching from 1 through that value. Candidate vectors are sorted and deduplicated so that result names, plots, and returned dimensions remain aligned.

## Tests

The new tests cover:

- correct reporting from a non-consecutive PC grid;
- application of the requested discriminant dimension; and
- validation of PC dimensions, DA dimensions, simulation counts, and logical controls.

All 9 focused expectations pass with this change. Against the current implementation, the same tests expose the incorrect PC result, the ignored `n.da` argument, and the absent validation.