### PR TITLE
Handle missing and zero-variance loci consistently in glPca

### DIFF
--- a/R/glFunctions.R
+++ b/R/glFunctions.R
@@ -290,6 +290,12 @@ glPca <- function(x, center=TRUE, scale=FALSE, nf=NULL, loadings=TRUE, alleleAsU
     if(scale){
         vecVar <- glVar(x, alleleAsUnit=alleleAsUnit)
         if(any(is.na(vecVar))) stop("NAs detected in the vector of variances")
+        nullVar <- vecVar < 1e-10
+        if(any(nullVar)) {
+            warning("Null variances have been detected; corresponding alleles won't be standardized.")
+        }
+        vecVarSafe <- vecVar
+        vecVarSafe[nullVar] <- 1
     }
 
 
@@ -339,7 +345,7 @@ glPca <- function(x, center=TRUE, scale=FALSE, nf=NULL, loadings=TRUE, alleleAsU
                     a[is.na(a)] <- 0
                     b <- as.integer(b) / ploid.b
                     b[is.na(b)] <- 0
-                    return(sum( (a*b)/vecVar, na.rm=TRUE))
+                    return(sum( (a*b)/vecVarSafe, na.rm=TRUE))
                 }
             }
 
@@ -351,7 +357,7 @@ glPca <- function(x, center=TRUE, scale=FALSE, nf=NULL, loadings=TRUE, alleleAsU
                     a[is.na(a)] <- vecMeans[is.na(a)]
                     b <- as.integer(b) / ploid.b
                     b[is.na(b)] <- vecMeans[is.na(b)]
-                    return( sum( ((a-vecMeans)*(b-vecMeans))/vecVar, na.rm=TRUE ) )
+                    return( sum( ((a-vecMeans)*(b-vecMeans))/vecVarSafe, na.rm=TRUE ) )
                 }
             }
 
@@ -419,7 +425,7 @@ glPca <- function(x, center=TRUE, scale=FALSE, nf=NULL, loadings=TRUE, alleleAsU
     ## but only two such matrices are represented at a time
     if(loadings){
         if(scale) {
-            vecSd <- sqrt(vecVar)
+            vecSd <- sqrt(vecVarSafe)
         }
         res$loadings <- matrix(0, nrow=nLoc(x), ncol=nf) # create empty matrix
         ## use: c1 = X^TDV

--- a/man/glPca.Rd
+++ b/man/glPca.Rd
@@ -125,6 +125,21 @@ glPca(x, center = TRUE, scale = FALSE, nf = NULL, loadings = TRUE,
   Lastly, note that using compiled C code (\code{useC=TRUE})is an
   alternative for speeding up computations, but cannot be used together
   with the parallel option.
+
+  === Missing genotypes and invariant loci ===
+
+  Missing genotypes are replaced internally by the mean allele frequency
+  at their locus. After centring, these entries therefore contribute zero
+  to the PCA. This permits the analysis to run with incomplete SNP data,
+  but it is a mean-imputation rule rather than an estimate of the missing
+  genotype. Missingness should be inspected before analysis because
+  differences among individuals or groups can affect distances, scores,
+  and downstream analyses based on this PCA.
+
+  When \code{scale=TRUE}, loci with null variance cannot be standardized.
+  They are retained without division by zero and have no contribution to a
+  centred PCA. Filtering invariant loci before PCA is nevertheless
+  recommended.
 }
 \value{
   === glPca objects ===

--- a/tests/testthat/test-glPca-preprocessing.R
+++ b/tests/testthat/test-glPca-preprocessing.R
@@ -1,0 +1,54 @@
+test_that("glPca handles invariant loci consistently when scaling", {
+    genotypes <- matrix(
+        c(0, 0, 0, 0,
+          0, 1, 2, 1,
+          0, NA, 2, 1),
+        nrow = 4
+    )
+    colnames(genotypes) <- c("fixed", "variable", "incomplete")
+    rownames(genotypes) <- paste0("individual", seq_len(nrow(genotypes)))
+    x <- new("genlight", genotypes)
+    indNames(x) <- rownames(genotypes)
+    locNames(x) <- colnames(genotypes)
+
+    expect_warning(
+        compiled <- glPca(x, center = TRUE, scale = TRUE, nf = 2,
+                          loadings = TRUE, useC = TRUE),
+        "Null variances"
+    )
+    expect_warning(
+        interpreted <- glPca(x, center = TRUE, scale = TRUE, nf = 2,
+                             loadings = TRUE, useC = FALSE),
+        "Null variances"
+    )
+
+    expect_true(all(is.finite(compiled$scores)))
+    expect_true(all(is.finite(compiled$loadings)))
+    expect_equal(compiled$loadings[1, ], c(Axis1 = 0, Axis2 = 0))
+    expect_equal(abs(compiled$scores), abs(interpreted$scores), tolerance = 1e-10)
+    expect_equal(abs(compiled$loadings), abs(interpreted$loadings),
+                 tolerance = 1e-10)
+})
+
+test_that("unscaled invariant loci agree between glPca implementations", {
+    genotypes <- matrix(
+        c(2, 2, 2, 2,
+          0, 1, 2, 1),
+        nrow = 4
+    )
+    x <- new("genlight", genotypes)
+
+    expect_warning(
+        compiled <- glPca(x, center = FALSE, scale = TRUE, nf = 2,
+                          loadings = FALSE, useC = TRUE),
+        "Null variances"
+    )
+    expect_warning(
+        interpreted <- glPca(x, center = FALSE, scale = TRUE, nf = 2,
+                             loadings = FALSE, useC = FALSE),
+        "Null variances"
+    )
+
+    expect_true(all(is.finite(compiled$scores)))
+    expect_equal(abs(compiled$scores), abs(interpreted$scores), tolerance = 1e-10)
+})


### PR DESCRIPTION
## Summary

This PR makes the preprocessing performed by `glPca()` safer and more transparent when SNP datasets contain missing genotypes or invariant loci.

## Problem

`glPca()` currently has inconsistent behaviour when `scale = TRUE` and one or more loci have zero variance:

- the compiled implementation replaces a zero standard deviation with a safe divisor;
- the pure-R implementation divides directly by zero;
- centred analyses can return `NaN` loadings for invariant loci;
- uncentred, scaled analyses using `useC = FALSE` can fail during eigenanalysis with `infinite or missing values in 'x'`.

These are realistic conditions in SNP workflows. An invariant marker may remain after sample removal, population subsetting, quality filtering, or analysis of a subset of individuals—even when the marker was polymorphic in the original dataset.

Missing-genotype handling was also not described in the `glPca()` documentation. The implementation replaces a missing genotype with its locus mean. After centring, that entry contributes zero to the PCA. This permits incomplete data to be analysed, but it is mean imputation rather than inference of the missing genotype. Unequal missingness among individuals, sequencing batches, populations, or other groups may therefore affect PCA distances and downstream DAPC or clustering results.

## Changes

- Detect zero-variance loci once during preprocessing.
- Warn users when such loci are present.
- Use a safe variance divisor consistently in compiled and pure-R calculations.
- Prevent invariant loci from producing non-finite loadings.
- Document the locus-mean imputation applied to missing genotypes.
- Explain why missingness should be inspected before interpreting PCA, DAPC, or clustering results.
- Recommend filtering invariant loci before PCA.

## Tests

The new regression tests cover centred and uncentred scaled analyses containing invariant and incomplete loci. They verify that:

- PCA scores remain finite;
- loadings remain finite;
- invariant loci have zero loadings in a centred PCA;
- compiled and pure-R implementations return equivalent scores and loadings;
- the pure-R implementation no longer fails during eigenanalysis.

The focused test file passes 11 expectations.